### PR TITLE
feat: Post 검색 엔드포인트 & DTo 정리

### DIFF
--- a/src/main/java/io/routepickapi/controller/PostController.java
+++ b/src/main/java/io/routepickapi/controller/PostController.java
@@ -109,4 +109,26 @@ public class PostController {
 
     public record LikeResponse(int likeCount) {}
     public record ApiMessage(String message) {}
+
+    /**
+     * 게시글 검색 API
+     *  - region(선택): 지역명 완전일치
+     *  - keyword(선택): 제목/내용 부분일치(대소문자 무시)
+     *  - pageable: page, size, sort(예: sort=createdAt.desc)
+     *  - 반환: 목록 화면용 경량 DTO(Page)
+     */
+    @Operation(
+        summary = "게시글 검색",
+        description = "region(선택), keyword(선택)로 검색. 기본 정렬은 createdAt DESC"
+    )
+    @GetMapping("/search")
+    public Page<PostListItemResponse> search(
+        @Parameter(description = "지역명(완전일치)") @RequestParam(required = false) String region,
+        @Parameter(description = "키워드(제목/본문에 포함)") @RequestParam(required = false) String keyword,
+        @ParameterObject @PageableDefault(size = 20) Pageable pageable
+    ) {
+        log.debug("GET /posts/search - region='{}', keyword='{}', page={}, size={}",
+            region, keyword, pageable.getPageNumber(), pageable.getPageSize());
+        return postService.search(region, keyword, pageable);
+    }
 }


### PR DESCRIPTION
- GET /posts/search 검색 API 추가 (지역/키워드/페이지네이션)
- 목록/검색 공용 DTO로 PostListItemResponse 정리 (from(post) 매핑제공)
- QueryDSL 기반 동적 쿼리 사용(상태=ACTIVE, region/keyword 조건, 최신순)
- Lazy 컬렉션(tags) 직렬화 이슈 회피(목록/검색에서는 태그 미노출)