### PR TITLE
feat: 댓글 좋아요 API , 소프트 삭제 API 추가

### DIFF
--- a/src/main/java/io/routepickapi/controller/CommentController.java
+++ b/src/main/java/io/routepickapi/controller/CommentController.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -89,6 +90,20 @@ public class CommentController {
         log.info("Reply liked: postId={}, commentId={}, likeCount={}", postId, commentId,
             likeCount);
         return ResponseEntity.ok(new LikeResponse(commentId, likeCount));
+    }
+
+    @Operation(summary = "댓글 삭제(소프트)", description = "특정 게시글 내 댓글을 소프트 삭제합니다.")
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<Void> delete(
+        @Parameter(description = "게시글 ID") @PathVariable @Min(1) Long postId,
+        @Parameter(description = "댓글 ID") @PathVariable @Min(1) Long commentId
+    ) {
+        log.debug("DELETE /posts/{}/comments/{} - request received", postId, commentId);
+
+        commentService.softDelete(postId, commentId);
+
+        log.info("Comment soft-deleted: postId={}, commentId={}", postId, commentId);
+        return ResponseEntity.noContent().build();
     }
 
     public record IdResponse(Long id) {

--- a/src/main/java/io/routepickapi/repository/CommentRepository.java
+++ b/src/main/java/io/routepickapi/repository/CommentRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 /**
  * 댓글 기본 CRUD + 조회용 쿼리 메서드
@@ -39,11 +38,16 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         + "where c.id = :commentId "
         + "and c.post.id = :postId "
         + "and c.status = :status")
-    int incrementLikeCount(
-        @Param("postId") Long postId,
-        @Param("commentId") Long commentId,
-        @Param("status") CommentStatus status
-    );
+    int incrementLikeCount(Long postId, Long commentId, CommentStatus status);
+
+    // 소프트 삭제 (ACTIVE -> DELETED)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Comment c "
+        + "set c.status = :to "
+        + "where c.id = :commentId "
+        + "and c.post.id = :postId "
+        + "and c.status = :from")
+    int updateStatus(Long postId, Long commentId, CommentStatus from, CommentStatus to);
 
     // 필요 시 조회용
     Optional<Comment> findByIdAndPostIdAndStatus(Long id, Long postId, CommentStatus status);

--- a/src/main/java/io/routepickapi/service/CommentService.java
+++ b/src/main/java/io/routepickapi/service/CommentService.java
@@ -135,4 +135,20 @@ public class CommentService {
             likeCount);
         return likeCount;
     }
+
+    @Transactional
+    public void softDelete(Long postId, Long commentId) {
+        log.debug("Delete comment request: postId={}, commentId={}", postId, commentId);
+
+        int updated = commentRepository.updateStatus(
+            postId, commentId, CommentStatus.ACTIVE, CommentStatus.DELETED
+        );
+
+        if (updated == 0) {
+            log.warn("Delete failed (not found or not ACTIVE): postId={}, commentId={}", postId,
+                commentId);
+        }
+
+        log.info("Comment soft-deleted: postId={}, commentId={}", postId, commentId);
+    }
 }


### PR DESCRIPTION
### 요약
- 댓글 좋아요 증가 엔드포인트 추가
- 서비스/컨트롤러 로그 추가
- JPQL update로 원자적 증가
- +) 댓글 소프트 삭제 제공
- +) JPQL update로 status=DELETED 전환 
---
### API
- POST /posts/{postId}/comments/{commentId}/like
  - 해당 게시글 내 특정 댓글의 like_count 1 증가
  - 성공 시 200 OK + {"id": <commentId>, "likeCount": <증가 후 카운트>}
  - 조건 불일치(다른 게시글 소속/비활성/존재 X) 시 404 Not found
  - +) DELETE /posts/{postId}/comments/{commentIdId}추가
  - +) 댓글 삭제 성공 시 204 No Content
