### PR TITLE
feat: use QueryDSL for paged root+replies listing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ configurations {
 }
 
 
-
 repositories {
     mavenCentral()
 }
@@ -60,7 +59,6 @@ configurations.configureEach {
         }
     }
 }
-
 
 
 tasks.named('test') {

--- a/src/main/java/io/routepickapi/repository/CommentRepository.java
+++ b/src/main/java/io/routepickapi/repository/CommentRepository.java
@@ -2,10 +2,7 @@ package io.routepickapi.repository;
 
 import io.routepickapi.entity.comment.Comment;
 import io.routepickapi.entity.comment.CommentStatus;
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -15,22 +12,8 @@ import org.springframework.data.repository.query.Param;
  * 댓글 기본 CRUD + 조회용 쿼리 메서드
  * - 스프링 데이터 JPA의 쿼리 메서드 규칙으로 페이징/정렬/리스트 조회 처리
  */
-public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-    // 1) 본댓글 페이지: 항상 ACTIVE, 최신순
-    Page<Comment> findByPostIdAndParentIsNullAndStatusOrderByCreatedAtDesc(
-        Long postId, CommentStatus status, Pageable pageable
-    );
-
-    // 2) 특정 부모의 대댓글: 항상 ACTIVE, 작성시간 오름차순
-    List<Comment> findByParentIdAndStatusOrderByCreatedAtAsc(
-        Long parentId, CommentStatus status
-    );
-
-    // 3) 여러 부모의 대댓글을 한번에 로딩(본댓글 페이지는 일괄로딩)
-    List<Comment> findByParentIdInAndStatusOrderByCreatedAtAsc(
-        List<Long> parentIds, CommentStatus status
-    );
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
+    
 
     // JPQL 로 like_count 증가
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -59,5 +42,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // 필요 시 조회용
     Optional<Comment> findByIdAndPostIdAndStatus(Long id, Long postId, CommentStatus status);
-
 }

--- a/src/main/java/io/routepickapi/repository/CommentRepositoryCustom.java
+++ b/src/main/java/io/routepickapi/repository/CommentRepositoryCustom.java
@@ -1,0 +1,24 @@
+package io.routepickapi.repository;
+
+import io.routepickapi.entity.comment.Comment;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentRepositoryCustom {
+
+    /**
+     * 루트 댓글 페이지:
+     * - ACTIVE 는 항상 노출
+     * - DELETED 라도 ACTVIE 자식이 하나로 있으면 노출
+     * - 최신순
+     */
+    Page<Comment> findRootsForList(Long postId, Pageable pageable);
+
+    /**
+     * 여러 부모의 대댓글 일괄 로딩:
+     * - ACTIVE 만
+     * - 작성시간 오름차순
+     */
+    List<Comment> findActiveReplies(List<Long> parentIds);
+}

--- a/src/main/java/io/routepickapi/repository/CommentRepositoryImpl.java
+++ b/src/main/java/io/routepickapi/repository/CommentRepositoryImpl.java
@@ -1,0 +1,108 @@
+package io.routepickapi.repository;
+
+import static io.routepickapi.entity.comment.QComment.comment;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.routepickapi.entity.comment.Comment;
+import io.routepickapi.entity.comment.CommentStatus;
+import io.routepickapi.entity.comment.QComment;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 루트 댓글 페이지
+     * - ACTIVE 는 항상 노출
+     * - DELETED 라도 ACTIVE 자식이 1개 이상 있으면 노출
+     * - 최신순(createdAt desc)
+     */
+
+    @Override
+    public Page<Comment> findRootsForList(Long postId, Pageable pageable) {
+        QComment r = comment;
+        QComment ch = new QComment("ch");
+
+        // content 조회
+        List<Comment> content = queryFactory
+            .selectFrom(r)
+            .where(
+                r.post.id.eq(postId),
+                r.parent.isNull(),
+                r.status.eq(CommentStatus.ACTIVE)
+                    .or(
+                        r.status.eq(CommentStatus.DELETED)
+                            .and(
+                                JPAExpressions
+                                    .selectOne()
+                                    .from(ch)
+                                    .where(
+                                        ch.parent.eq(r),
+                                        ch.status.eq(CommentStatus.ACTIVE)
+                                    )
+                                    .exists()
+                            )
+                    )
+            )
+            .orderBy(r.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        // count 쿼리 (동일 조건)
+        JPAQuery<Long> countQuery = queryFactory
+            .select(r.count())
+            .from(r)
+            .where(
+                r.post.id.eq(postId),
+                r.parent.isNull(),
+                r.status.eq(CommentStatus.ACTIVE)
+                    .or(
+                        r.status.eq(CommentStatus.DELETED)
+                            .and(
+                                JPAExpressions
+                                    .selectOne()
+                                    .from(ch)
+                                    .where(
+                                        ch.parent.eq(r),
+                                        ch.status.eq(CommentStatus.ACTIVE)
+                                    )
+                                    .exists()
+                            )
+                    )
+            );
+        // count 최적화: content 사이즈로 생략 가능하면 생략
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 대댓글 일괄 조회
+     * - ACTIVE 만 노출
+     * - 작성시간 오름차순(createdAt asc)
+     */
+    @Override
+    public List<Comment> findActiveReplies(List<Long> parentIds) {
+        if (parentIds == null || parentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        QComment c = comment;
+        return queryFactory
+            .selectFrom(c)
+            .where(
+                c.parent.id.in(parentIds),
+                c.status.eq(CommentStatus.ACTIVE)
+            )
+            .orderBy(c.createdAt.asc())
+            .fetch();
+    }
+}


### PR DESCRIPTION
### Summary
- 루트 댓글 페이지/대댓글 조회를 QueryDSL 기반으로 교체
- 루트: ACTIVE는 항상, DELETED라도 ACTIVE 자식이 1개 이상이면 노출 (최신순)
- 대댓글: ACTIVE만 노출 (작성시간 오름차순)
- 좋아요 증가/소프트 삭제는 기존 JPQL(원자적 업데이트) 유지

### Changes
- `CommentRepositoryCustom`, `CommentRepositoryImpl` 추가
- `CommentService.listRootsWithReplies()`가 커스텀 리포지토리 사용

### Why
- 복잡한 조건/exists 서브쿼리를 타입 세이프하게 작성
- 향후 조건 확장/최적화 용이

### Test
- 로컬 빌드/실행 후 Swagger로 CRUD/목록/좋아요/삭제 시나리오 수동 검증