### PR TITLE
Feat/comment update

### DIFF
--- a/src/main/java/io/routepickapi/controller/CommentController.java
+++ b/src/main/java/io/routepickapi/controller/CommentController.java
@@ -2,6 +2,7 @@ package io.routepickapi.controller;
 
 import io.routepickapi.dto.comment.CommentCreateRequest;
 import io.routepickapi.dto.comment.CommentResponse;
+import io.routepickapi.dto.comment.CommentUpdateRequest;
 import io.routepickapi.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -104,6 +106,21 @@ public class CommentController {
 
         log.info("Comment soft-deleted: postId={}, commentId={}", postId, commentId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "댓글 내용 수정", description = "ACTIVE 상태의 댓글 내용만 수정 가능")
+    @PatchMapping("/{postId}/comments/{commentId}")
+    public ResponseEntity<CommentResponse> update(
+        @Parameter(description = "게시글 ID") @PathVariable @Min(1) Long postId,
+        @Parameter(description = "댓글 ID") @PathVariable @Min(1) Long commentId,
+        @Valid @RequestBody CommentUpdateRequest req
+    ) {
+        log.debug("PATCH /posts/{}/comments/{} - request received", postId, commentId);
+
+        CommentResponse updated = commentService.updateContent(postId, commentId, req);
+
+        log.info("Comment updated: postId={}, commentId={}", postId, commentId);
+        return ResponseEntity.ok(updated); // 200 OK + 갱신된 리소스 반환
     }
 
     public record IdResponse(Long id) {

--- a/src/main/java/io/routepickapi/dto/comment/CommentResponse.java
+++ b/src/main/java/io/routepickapi/dto/comment/CommentResponse.java
@@ -16,13 +16,20 @@ public record CommentResponse(
     LocalDateTime createdAt,
     List<CommentResponse> replies
 ) {
+
+    private static String maskIfDeleted(Comment c) {
+        return (c.getStatus() == CommentStatus.DELETED)
+            ? "(삭제된 댓글입니다)"
+            : c.getContent();
+    }
+
     public static CommentResponse from(Comment c) {
         Long pId = (c.getParent() == null) ? null : c.getParent().getId();
         return new CommentResponse(
             c.getId(),
             pId,
             c.getDepth(),
-            c.getContent(),
+            maskIfDeleted(c),
             c.getLikeCount(),
             c.getStatus(),
             c.getCreatedAt(),
@@ -40,7 +47,7 @@ public record CommentResponse(
             root.getId(),
             pId,
             root.getDepth(),
-            root.getContent(),
+            maskIfDeleted(root),
             root.getLikeCount(),
             root.getStatus(),
             root.getCreatedAt(),

--- a/src/main/java/io/routepickapi/dto/comment/CommentUpdateRequest.java
+++ b/src/main/java/io/routepickapi/dto/comment/CommentUpdateRequest.java
@@ -1,0 +1,12 @@
+package io.routepickapi.dto.comment;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CommentUpdateRequest(
+    @NotBlank
+    @Size(max = 1000)
+    String content
+) {
+
+}

--- a/src/main/java/io/routepickapi/service/CommentService.java
+++ b/src/main/java/io/routepickapi/service/CommentService.java
@@ -2,6 +2,7 @@ package io.routepickapi.service;
 
 import io.routepickapi.dto.comment.CommentCreateRequest;
 import io.routepickapi.dto.comment.CommentResponse;
+import io.routepickapi.dto.comment.CommentUpdateRequest;
 import io.routepickapi.entity.comment.Comment;
 import io.routepickapi.entity.comment.CommentStatus;
 import io.routepickapi.entity.post.Post;
@@ -145,6 +146,21 @@ public class CommentService {
         }
 
         log.info("Comment soft-deleted: postId={}, commentId={}", postId, commentId);
+    }
+
+    @Transactional
+    public CommentResponse updateContent(Long postId, Long commentId, CommentUpdateRequest req) {
+        // ACTIVE 인 대상만 수정 허용
+        Comment c = commentRepository
+            .findByIdAndPostIdAndStatus(commentId, postId, CommentStatus.ACTIVE)
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND, "comment not available"
+            ));
+        
+        c.changeContent(req.content()); // 엔티티 유효성 검증 포함(<=1000, not blank)
+
+        log.info("Comment updated: postId={}, commentId={}", postId, commentId);
+        return CommentResponse.from(c); // DTO 마스킹 규칙 적용
     }
 
 


### PR DESCRIPTION
- 댓글 수정 API 추가: PATCH /posts/{postId}/comments/{commentId}
- 활성(ACTIVE) 댓글만 수정 가능, 삭제(DELETED) 404 (comment not available)
- 요청 DTO CommentupdateRequest 추가 (not blank, <= 1000자)
- 비즈니스 로직에서 엔티티 changeContent() 호출, 트랜잭션 내 flush
- CommenResponse 응답(삭제 마스킹 로직 유지)