### PR TITLE
Feat/post update delete

### DIFF
--- a/src/main/java/io/routepickapi/controller/PostController.java
+++ b/src/main/java/io/routepickapi/controller/PostController.java
@@ -3,6 +3,7 @@ package io.routepickapi.controller;
 import io.routepickapi.dto.post.PostCreateRequest;
 import io.routepickapi.dto.post.PostListItemResponse;
 import io.routepickapi.dto.post.PostResponse;
+import io.routepickapi.dto.post.PostUpdateRequest;
 import io.routepickapi.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,7 +43,7 @@ public class PostController {
     @PostMapping
     public ResponseEntity<PostResponse> create(@Valid @RequestBody PostCreateRequest req) {
 
-        log.debug("POST /posts - title='{}';, region='{}' tags={}", req.title(), req.region(),
+        log.debug("POST /posts - title='{}', region='{}' tags={}", req.title(), req.region(),
             req.tags());
         Long id = postService.create(req);
         PostResponse body = postService.getDetail(id, false); // 생성 직후 본분 반환(조회수 증가 X)
@@ -130,6 +131,24 @@ public class PostController {
         log.debug("GET /posts/search - region='{}', keyword='{}', page={}, size={}",
             region, keyword, pageable.getPageNumber(), pageable.getPageSize());
         return postService.search(region, keyword, pageable);
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "게시글 수정", description = "전달된 필드만 변경하고, 수정된 게시글 200 반환")
+    public ResponseEntity<PostResponse> update(
+        @Parameter(description = "게시글 ID") @PathVariable(name = "id") @Min(1) Long id,
+        @Valid @RequestBody PostUpdateRequest req
+    ) {
+        log.debug(
+            "PATCH /posts/{} - title?={}, content?={}, region?={}, lat?={}, lon?={}, tags?={}",
+            id,
+            req.title() != null, req.content() != null, req.region() != null,
+            req.latitude() != null, req.longitude() != null, req.tags() != null);
+
+        PostResponse body = postService.update(id, req);
+
+        log.info("Post Updated: id={}", id);
+        return ResponseEntity.ok(body);
     }
 
 

--- a/src/main/java/io/routepickapi/controller/PostController.java
+++ b/src/main/java/io/routepickapi/controller/PostController.java
@@ -91,12 +91,12 @@ public class PostController {
     // 소프트 삭제
     @Operation(summary = "게시글 소프트 삭제", description = "status=DELETED로 변환(물리삭제 X)")
     @DeleteMapping("/{id}")
-    public ApiMessage softDelete(
+    public ResponseEntity<Void> softDelete(
         @Parameter(description = "게시글 ID")
         @PathVariable(name = "id") @Min(1) Long id) {
         postService.softDelete(id);
         log.info("Post Soft-Deleted: id={}", id);
-        return new ApiMessage("deleted");
+        return ResponseEntity.noContent().build(); // 반환값 204로 수정
     }
 
     // 게시글 활성화
@@ -131,6 +131,7 @@ public class PostController {
             region, keyword, pageable.getPageNumber(), pageable.getPageSize());
         return postService.search(region, keyword, pageable);
     }
+
 
     public record LikeResponse(int likeCount) {
 

--- a/src/main/java/io/routepickapi/dto/post/PostCreateRequest.java
+++ b/src/main/java/io/routepickapi/dto/post/PostCreateRequest.java
@@ -1,7 +1,9 @@
 package io.routepickapi.dto.post;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
@@ -9,8 +11,20 @@ import java.util.List;
 public record PostCreateRequest(
     @NotBlank @Size(max = 120) String title,
     @NotBlank @Size(max = 4000) String content,
+
+    @Size(max = 120)
+    @Pattern(regexp = ".*\\S.*", message = "region은 공백만으로는 허용되지 않습니다.")
+    String region,
+
     Double latitude,
     Double longitude,
-    @Size(max = 120) String region,
-    List<String> tags
-) {}
+
+    @Size(max = 50)
+    List<@Pattern(regexp = ".*\\S.*", message = "태그는 공백만으로는 허용되지 않습니다.") @Size(max = 40) String> tags
+) {
+
+    @AssertTrue(message = "latitude/longitude 둘 다 함께 제공되어야 합니다.")
+    public boolean isValidCoordinates() {
+        return (latitude == null && longitude == null) || (latitude != null && longitude != null);
+    }
+}

--- a/src/main/java/io/routepickapi/dto/post/PostUpdateRequest.java
+++ b/src/main/java/io/routepickapi/dto/post/PostUpdateRequest.java
@@ -1,0 +1,34 @@
+package io.routepickapi.dto.post;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "게시글 수정 요청(PATCH) - 전달된 필드만 변경")
+public record PostUpdateRequest(
+    @Size(max = 120)
+    @Pattern(regexp = ".*\\S.*", message = "title은 공백만으로는 허용되지 않습니다.")
+    String title,
+
+    @Size(max = 4000)
+    @Pattern(regexp = ".*\\S.*", message = "content는 공백만으로는 허용되지 않습니다.")
+    String content,
+
+    @Size(max = 120)
+    @Pattern(regexp = ".*\\S.*", message = "region은 공백만으로는 허용되지 않습니다.")
+    String region,
+
+    Double latitude,
+    Double longitude,
+
+    @Size(max = 50)
+    List<@Pattern(regexp = ".*\\S.*", message = "태그는 공백만으로는 허용되지 않습니다.") @Size(max = 40) String> tags
+) {
+
+    @AssertTrue(message = "latitude/longitude는 둘 다 함께 제공되어야 합니다.")
+    public boolean isValidCoordinates() {
+        return (latitude == null && longitude == null) || (latitude != null && longitude != null);
+    }
+}

--- a/src/main/java/io/routepickapi/entity/post/Post.java
+++ b/src/main/java/io/routepickapi/entity/post/Post.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 
 @Entity
 @Table(
-    name="posts",
+    name = "posts",
     indexes = {
         @Index(name = "idx_posts_created_at", columnList = "created_at"),
         @Index(name = "idx_posts_region_created_at", columnList = "region, created_at"),
@@ -33,6 +33,7 @@ import lombok.Setter;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -70,8 +71,12 @@ public class Post extends BaseEntity {
     private List<String> tags = new ArrayList<>();
 
     public Post(String title, String content) {
-        if (title == null || title.isBlank()) throw new IllegalArgumentException("title required");
-        if (content == null || content.isBlank()) throw new IllegalArgumentException("content required");
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("title required");
+        }
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("content required");
+        }
         this.title = title;
         this.content = content;
     }
@@ -83,16 +88,47 @@ public class Post extends BaseEntity {
 
     public void setTags(List<String> tags) {
         this.tags.clear();
-        if (tags == null) return;
+        if (tags == null) {
+            return;
+        }
         for (String t : tags) {
-            if (t != null && !t.isBlank() && t.length() <= 40) this.tags.add(t);
+            if (t != null && !t.isBlank() && t.length() <= 40) {
+                this.tags.add(t);
+            }
         }
     }
 
-    public void hide() { this.status = PostStatus.HIDDEN; }
-    public void softDelete() { this.status = PostStatus.DELETED; }
-    public void activated() { this.status = PostStatus.ACTIVE; }
+    public void changeTitle(String title) {
+        if (title == null || title.isBlank() || title.length() > 120) {
+            throw new IllegalArgumentException("invalid title");
+        }
+        this.title = title;
+    }
 
-    public void increaseView() { this.viewCount++; }
-    public void increaseLike() { this.likeCount++; }
+    public void changeContent(String content) {
+        if (content == null || content.isBlank() || content.length() > 4000) {
+            throw new IllegalArgumentException("invalid content");
+        }
+        this.content = content;
+    }
+
+    public void hide() {
+        this.status = PostStatus.HIDDEN;
+    }
+
+    public void softDelete() {
+        this.status = PostStatus.DELETED;
+    }
+
+    public void activated() {
+        this.status = PostStatus.ACTIVE;
+    }
+
+    public void increaseView() {
+        this.viewCount++;
+    }
+
+    public void increaseLike() {
+        this.likeCount++;
+    }
 }

--- a/src/main/java/io/routepickapi/service/PostService.java
+++ b/src/main/java/io/routepickapi/service/PostService.java
@@ -3,6 +3,7 @@ package io.routepickapi.service;
 import io.routepickapi.dto.post.PostCreateRequest;
 import io.routepickapi.dto.post.PostListItemResponse;
 import io.routepickapi.dto.post.PostResponse;
+import io.routepickapi.dto.post.PostUpdateRequest;
 import io.routepickapi.entity.post.Post;
 import io.routepickapi.entity.post.PostStatus;
 import io.routepickapi.repository.PostQueryRepository;
@@ -21,6 +22,7 @@ import org.springframework.web.server.ResponseStatusException;
 @RequiredArgsConstructor
 @Transactional
 public class PostService {
+
     private final PostRepository postRepository;
     private final PostQueryRepository postQueryRepository; // 동적 검색용 QueryDSL 리포지토리
 
@@ -36,7 +38,8 @@ public class PostService {
         post.setTags(req.tags());
 
         Long id = postRepository.save(post).getId();
-        log.info("Create Post: id={}, title='{}', region='{}'", id, post.getTitle(), post.getRegion());
+        log.info("Create Post: id={}, title='{}', region='{}'", id, post.getTitle(),
+            post.getRegion());
         return id;
     }
 
@@ -54,7 +57,7 @@ public class PostService {
 
     public PostResponse getDetail(Long id, boolean increaseView) {
         Post post = postRepository.findWithTagsById(id)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,  "post not found"));
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "post not found"));
 
         if (post.getStatus() != PostStatus.ACTIVE) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "post not available");
@@ -69,7 +72,8 @@ public class PostService {
 
     public int like(Long id) {
         Post post = postRepository.findByIdAndStatus(id, PostStatus.ACTIVE)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "post not available"));
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "post not available"));
         post.increaseLike();
         log.debug("Increase Like: id={}, newLikeCount={}", id, post.getLikeCount());
         return post.getLikeCount();
@@ -101,5 +105,38 @@ public class PostService {
         Page<Post> page = postQueryRepository.searchByRegionAndKeyword(region, keyword, pageable);
         // 목록 응답은 Lazy 컬렉션(tags) 접근하지 않는 경량 DTO로 매핑 -> Lazy 예외 예방
         return page.map(PostListItemResponse::from);
+    }
+
+    public PostResponse update(Long id, PostUpdateRequest req) {
+        // DELETED 는 수정 불가, ACTIVE/HIDDEN 은 수정 허용
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "post not found"));
+
+        if (post.getStatus() == PostStatus.DELETED) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "post not available");
+        }
+
+        // 전달된 필드만 변경 (null은 무시)
+        if (req.title() != null) {
+            post.changeTitle(req.title());
+        }
+        if (req.content() != null) {
+            post.changeContent(req.content());
+        }
+        if (req.region() != null) {
+            post.setRegion(req.region());
+        }
+
+        if (req.latitude() != null && req.longitude() != null) {
+            post.setCoordinates(req.latitude(), req.longitude());
+        }
+        if (req.tags() != null) {
+            post.setTags(req.tags());
+        }
+
+        log.info("Post Updated: id={}", id);
+
+        // 수정된 최신 본문 반환
+        return PostResponse.from(post);
     }
 }


### PR DESCRIPTION
### 게시글 수정/삭제 API 추가 (PATCH 200, DELETE 204)
- PATCH /posts/{id}: 전달된 필드만 부분 수정, 200 OK + PostResponse 반환
- DELETE /posts/{id}: 소프트 삭제(status=DELETED), 204 No Content 반환
- DTO 유효성 (좌표 쌍 검증, 공백 입력 방지, 길이 제한)
- 엔티티 도메인 메서드 검증 강화(제목/본문 변경 시 유효성 체크)
>  스키마 변경 없음, 하위 호환성 문제없음
---
### 변경 사항
**Controller**
- PostController
  - PATCH /posts/{id} → 수정된 리소스 200 OK 반환
  - DELETE /posts/{id} → 204 No Content
  - 요청/응답 로깅 추가

**Service**
- PostService
  - update(Long id, PostUpdateRequest req)
    - DELETED 상태는 수정 불가(404)
    - 전달된 필드만 반영 (null 무시)
    - 수정 후 최신 PostResponse 반환
  - softDelete(Long id) → status=DELETED 전환
  - 기존 getDetail/like 흐름 유지

**DTO**
- PostCreateRequest, PostUpdateRequest
  - @AssertTrue 로 latitude/longitude 쌍 검증
  - region/tags에 공백 입력 방지 @Pattern
  - 길이 제한 부여(title<=120, content<=4000, region<=120, tag<=40, tags<=50)

**Entity**
- Post
  - changeTitle, changeContent에서 blank/length 검증