### PR TITLE
Refactor/post search querydsl

### DIFF
--- a/src/main/java/io/routepickapi/repository/PostQueryRepositoryImpl.java
+++ b/src/main/java/io/routepickapi/repository/PostQueryRepositoryImpl.java
@@ -1,22 +1,23 @@
 package io.routepickapi.repository;
 
+import static io.routepickapi.entity.post.QPost.post;
+
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import io.routepickapi.entity.post.Post;
 import io.routepickapi.entity.post.PostStatus;
-import io.routepickapi.entity.post.QPost;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 /**
- * QueryDSL 구현부.
- * 동적 조건(BooleanBuilder) + 페이지/정렬 적용 + 카운트 쿼리 분리
+ * QueryDSL 구현부. 동적 조건(BooleanBuilder) + 페이지/정렬 적용 + 카운트 쿼리 분리
  */
 @Repository
 @RequiredArgsConstructor
@@ -26,69 +27,62 @@ public class PostQueryRepositoryImpl implements PostQueryRepository {
 
     @Override
     public Page<Post> searchByRegionAndKeyword(String region, String keyword, Pageable pageable) {
-        // 1) Q타입: 엔티티 Post의 메타클래스(컴파일 시 생성됨)
-        // - post.title, post.content, post.createdAt 같은 필드에 안전하게 접근 가능
-        QPost post = QPost.post;
-
-        // 2) 동적 where 조건
         BooleanBuilder where = new BooleanBuilder();
-        // 2-1) 상태는 ACTIVE만 노출
+        // 상태는 ACTIVE 만 노출
         where.and(post.status.eq(PostStatus.ACTIVE));
-        // 2-2) 지역 필터 (region이 비어있지 않다면)
+        // 지역 필터 (region 이 비어있지 않다면)
         if (region != null && !region.isBlank()) {
             where.and(post.region.eq(region));
         }
-        // 2-3) 키워드 검색: 제목 or 본문에 'keyword' 포함(대소문자 무시)
+        // 키워드 검색: 제목 or 본문에 'keyword' 포함(대소문자 무시)
         if (keyword != null && !keyword.isBlank()) {
-            // 제목 또는 본문에 키워드 포함
-            where.and(post.title.containsIgnoreCase(keyword)
-                .or(post.content.containsIgnoreCase(keyword)));
+            String k = keyword.trim();
+            where.and(post.title.containsIgnoreCase(k)
+                .or(post.content.containsIgnoreCase(k)));
         }
 
-        // 3) 정렬: 기본 createdAt DESC (페이지 정렬이 들어오면 우선 적용)
-        //         (pageable.getSort()로 들어온 정렬이 있다면 추가로 매핑 가능)
-        OrderSpecifier<?> defaultSort = post.createdAt.desc();
+        // 본문 쿼리
+        List<Post> content = queryFactory
+            .selectFrom(post)
+            .where(where)
+            .orderBy(orderSpecifiers(pageable)) // 정렬 매핑
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
 
-        // 4) 본문 조회 쿼리: select * from posts where ... order by ... limit ... offset ...
-        JPAQuery<Post> contentQuerry = queryFactory
-            .selectFrom(post)               // select post
-            .where(where)                   // where 조건들
-            .orderBy(defaultSort)           // 기본 정렬
-            .offset(pageable.getOffset())   // 페이지 시작 위치
-            .limit(pageable.getPageSize()); // 페이지 크기
-
-        // (선택) pageable 정렬 매핑: 필요할 때 확장
-        // pageable.getSort().forEach(order -> {
-        //     String prop = order.getProperty();
-        //     boolean asc = order.isAscending();
-        //     if ("createdAt".equals(prop)) {
-        //         contentQuery.orderBy(asc ? post.createdAt.asc() : post.createdAt.desc());
-        //     } else if ("likeCount".equals(prop)) {
-        //         contentQuery.orderBy(asc ? post.likeCount.asc() : post.likeCount.desc());
-        //     }
-        //     // 필요한 정렬 항목을 여기에 추가
-        // });
-
-        List<Post> content = contentQuerry.fetch(); // 실제 조회 실행
-
-        // 5) 카운트 쿼리: total count (페이지네이션 응답을 위해 분리)
+        // 카운트 쿼리
         JPAQuery<Long> countQuery = queryFactory
             .select(post.count())
             .from(post)
             .where(where);
 
-        /**
-         * fetchOne()은 Long(객체형)을 반환함
-         * 정상적으로는 COUNT(*)라서 0 이상 숫자 하나가 오지만, 프레임워크/드라이버에 따라 드물게 null이 올 수 있음(방어 코드)
-         * PageImpl 생성자 등에 넘길 때는 원시형 long이 편함
-         * 그냥 long total = countQuery.fetchOne(); 하면 null일 때 NPE 터짐
-         * 그래서 Long으로 받았다가 널 체크 후 언박싱(.longValue())하는 패턴을 씀
-         * */
-        Long totalBoxed = countQuery.fetchOne();
-        long total = (totalBoxed == null) ? 0L : totalBoxed.longValue();
+        // PageableExecutionUtils: 마지막 페이지 등에서 카운트 생략 최적화
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
 
-        // 6) 스프링 데이터의 page 구현체로 감싸서 반환
-        Page<Post> page = new PageImpl<>(content, pageable, total);
-        return page;
+    /**
+     * 정렬 화이트리스트 매핑
+     * - 허용: createdAt, likeCount, viewCount -미지정/빈 정렬이면 createdAt DESC 기본 적용
+     */
+    private OrderSpecifier<?>[] orderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        pageable.getSort().forEach(order -> {
+            String prop = order.getProperty();
+            boolean asc = order.isAscending();
+
+            if ("createdAt".equals(prop)) {
+                orders.add(asc ? post.createdAt.asc() : post.createdAt.desc());
+            } else if ("likeCount".equals(prop)) {
+                orders.add(asc ? post.likeCount.asc() : post.likeCount.desc());
+            } else if ("viewCount".equals(prop)) {
+                orders.add(asc ? post.viewCount.asc() : post.viewCount.desc());
+            }
+        });
+
+        if (orders.isEmpty()) {
+            orders.add(post.createdAt.desc());
+        }
+        return orders.toArray(new OrderSpecifier<?>[0]);
     }
 }

--- a/src/main/java/io/routepickapi/repository/PostRepository.java
+++ b/src/main/java/io/routepickapi/repository/PostRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -14,7 +17,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByStatusOrderByCreatedAtDesc(PostStatus status, Pageable pageable);
 
     // 지역 + 상태 필터 최신순 페이지 조회
-    Page<Post> findByRegionAndStatusOrderByCreatedAtDesc(String region, PostStatus status, Pageable pageable);
+    Page<Post> findByRegionAndStatusOrderByCreatedAtDesc(String region, PostStatus status,
+        Pageable pageable);
 
     // 상세 화면: 다건 조회 시 태그까지 로딩 (N+1 방지)
     @EntityGraph(attributePaths = "tags")
@@ -22,4 +26,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 상태까지 같이 확인하는 단건 조회(상세에서 숨김/삭제 걸러낼 떄)
     Optional<Post> findByIdAndStatus(Long id, PostStatus status);
+
+    // 동시성 안전 증가
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Post p set p.likeCount = p.likeCount + 1 "
+        + "where p.id = :id and p.status = :status")
+    int incrementLikeCount(@Param("id") Long id, @Param("status") PostStatus status);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Post p set p.viewCount = p.viewCount + 1 "
+        + "where p.id = :id and p.status = :status")
+    int incrementViewCount(@Param("id") Long id, @Param("status") PostStatus status);
 }


### PR DESCRIPTION
### 변경 내용
**검색 리포지토리 리팩터링 (QueryDSL)**
- PostQuerryRepositoryImpl
  - searchByRegionAndKeyword(String region, String keyword, Pageable pageable)
  - 조건: status = ACTIVE 고정, region 완전일치(선택), title OR content LIKE(선택)
  - 정렬 화이트리스트: createdAt, likeCount, viewCount
  
**좋아요/조회수 증가 동시성 보강**
- PostRepository
  - incrementLikeCount(@Param("id"), @Param("status"))
  - incrementViewCount(@Param("id"), @Param("status"))
  - 둘 다 @Modifying(clearAutomatically = true, flushAutomatically = true) 적용
 - PostService
   - /post/{id}?inView=true 시 DB 원자적 + 1 후 메모리 모델도 +1 일관성 유지
   - /post/{id}like 시 DB 원자적 + 1 후 최신 likeCount 재조회하여 반환
   - debug / info ㅗ르추가 