### PR TITLE
Feat/error unify

### DIFF
--- a/src/main/java/io/routepickapi/common/error/ErrorType.java
+++ b/src/main/java/io/routepickapi/common/error/ErrorType.java
@@ -3,19 +3,42 @@ package io.routepickapi.common.error;
 import org.springframework.http.HttpStatus;
 
 /*
-* API에서 공통으로 쓰는 에러
-* - httpStatus: HTTP 응답 코드
-* - code: FE/로그/문서에서 보는 짧은 식별자
-* - message: 기본 메세지(상세는 예외에서 덮어쓸 수 있음)
-*/
+ *  API 에서 공통으로 쓰는 에러
+ * - httpStatus: HTTP 응답 코드
+ * - code: FE/로그/문서에서 보는 짧은 식별자
+ * - message: 기본 메세지(상세는 예외에서 덮어쓸 수 있음)
+ */
 public enum ErrorType {
+
+    /* === 공통 === */
     COMMON_INVALID_INPUT(HttpStatus.BAD_REQUEST, "CMN-001", "유효하지 않은 입력입니다."),
-    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "CMN-404", "대상을 찾을 수 없습니다."),
+    COMMON_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "CMN-401", "인증이 필요합니다."),
     COMMON_FORBIDDEN(HttpStatus.FORBIDDEN, "CMN-003", "권한이 없습니다."),
+    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "CMN-404", "대상을 찾을 수 없습니다."),
+    COMMON_CONFLICT(HttpStatus.CONFLICT, "CMN-409", "이미 존재하거나 충돌이 발생했습니다."),
+    COMMON_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "CMN-429", "요청이 너무 많습니다."),
     COMMON_INTERNAL(HttpStatus.INTERNAL_SERVER_ERROR, "CMN-500", "서버 오류가 발생했습니다."),
 
-    // 도메인 별
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-404", "게시글을 찾을 수 없습니다.");
+    /* === 인증/토큰 === */
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH-401", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    AUTH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH-402", "유효하지 않은 토큰입니다."),
+    AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-403", "만료된 토큰입니다."),
+
+    /* === 유저 === */
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-404", "사용자를 찾을 수 없습니다."),
+    USER_BLOCKED(HttpStatus.FORBIDDEN, "USER-403", "차단된 사용자입니다."),
+    USER_EMAIL_EXISTS(HttpStatus.CONFLICT, "USER-409", "이미 사용 중인 이메일입니다."),
+
+    /* === 게시글 === */
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST-404", "게시글을 찾을 수 없습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "POST-403", "게시글에 대한 권한이 없습니다."),
+
+    /* === 댓글 === */
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CMT-404", "댓글을 찾을 수 없습니다."),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "CMT-403", "댓글에 대한 권한이 없습니다."),
+    COMMENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "CMT-400", "비활성/삭제된 댓글입니다."),
+    COMMENT_PARENT_MISMATCH(HttpStatus.BAD_REQUEST, "CMT-401", "부모 댓글이 게시글과 일치하지 않습니다."),
+    COMMENT_PARENT_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "CMT-402", "부모 댓글이 활성 상태가 아닙니다.");
 
     public final HttpStatus httpStatus;
     public final String code;

--- a/src/main/java/io/routepickapi/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/io/routepickapi/common/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,18 +21,51 @@ import org.springframework.web.server.ResponseStatusException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static Object safeRejectedValue(FieldError fe) {
+        Object v = fe.getRejectedValue();
+        if (v == null) {
+            return null;
+        }
+        String s = String.valueOf(v);
+        return s.length() > 200 ? s.substring(0, 200) + "..." : v;
+    }
+
+    /**
+     * 요청 추적용 ID(필요하면 필터에서 생성/주입, 지금은 헤더만 읽음)
+     */
+    private static String requestId(HttpServletRequest req) {
+        String h = req.getHeader("X-Request-Id");
+        return (h != null && !h.isBlank()) ? h : null;
+    }
+
     // 도메인/비즈니스 예외 -> ErrorType 기반 응답
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiErrorResponse> handleCustom(CustomException e, HttpServletRequest req) {
+    public ResponseEntity<ApiErrorResponse> handleCustom(CustomException e,
+        HttpServletRequest req) {
         ErrorType t = e.getType();
-        log.warn("CustomException : type={}, path={}, msg={}", t.code, req.getRequestURI(), e.getMessage());
-        ApiErrorResponse body = ApiErrorResponse.of(t, e.getMessage(), req.getRequestURI(), requestId(req), null);
+        log.warn("CustomException : type={}, path={}, msg={}", t.code, req.getRequestURI(),
+            e.getMessage());
+        ApiErrorResponse body = ApiErrorResponse.of(t, e.getMessage(), req.getRequestURI(),
+            requestId(req), null);
         return ResponseEntity.status(t.httpStatus).body(body);
     }
 
     // 본문 검증 실패 -> 필드 상세 포함해 400 반환
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiErrorResponse> handleInvalid(MethodArgumentNotValidException e, HttpServletRequest req) {
+    public ResponseEntity<ApiErrorResponse> handleInvalid(MethodArgumentNotValidException e,
+        HttpServletRequest req) {
+
+        // 로그인 엔드포인트는 검증 오류도 401로 통일
+        if (req.getRequestURI() != null && req.getRequestURI().endsWith("/auth/login")) {
+            ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorType.AUTH_INVALID_CREDENTIALS,
+                null,
+                req.getRequestURI(),
+                requestId(req),
+                null // 필드 상세 노출 금지
+            );
+            return ResponseEntity.status(ErrorType.AUTH_INVALID_CREDENTIALS.httpStatus).body(body);
+        }
         List<ApiErrorResponse.ApiFieldError> details = e.getBindingResult()
             .getFieldErrors()
             .stream()
@@ -54,7 +88,8 @@ public class GlobalExceptionHandler {
 
     // 파라미터(쿼리/경로) 검증 실패
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiErrorResponse> handleViolation(ConstraintViolationException e, HttpServletRequest req) {
+    public ResponseEntity<ApiErrorResponse> handleViolation(ConstraintViolationException e,
+        HttpServletRequest req) {
         List<ApiErrorResponse.ApiFieldError> details = e.getConstraintViolations().stream()
             .map(v -> new ApiErrorResponse.ApiFieldError(
                 v.getPropertyPath().toString(),
@@ -73,20 +108,25 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(ErrorType.COMMON_INVALID_INPUT.httpStatus).body(body);
     }
 
-    /** 그 외 예상 못한 모든 예외 → 500으로 통일 */
+    /**
+     * 그 외 예상 못한 모든 예외 → 500으로 통일
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiErrorResponse> handleEtc(Exception e, HttpServletRequest req) {
         log.error("Unexpected error: path={}, msg={}", req.getRequestURI(), e.getMessage(), e);
-        ApiErrorResponse body = ApiErrorResponse.of(ErrorType.COMMON_INTERNAL, null, req.getRequestURI(), requestId(req), null);
+        ApiErrorResponse body = ApiErrorResponse.of(ErrorType.COMMON_INTERNAL, null,
+            req.getRequestURI(), requestId(req), null);
         return ResponseEntity.status(ErrorType.COMMON_INTERNAL.httpStatus).body(body);
     }
 
     @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<ApiErrorResponse> handleRese(ResponseStatusException e, HttpServletRequest req) {
+    public ResponseEntity<ApiErrorResponse> handleRese(ResponseStatusException e,
+        HttpServletRequest req) {
         HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
 
         ErrorType type = switch (status) {
             case NOT_FOUND -> ErrorType.COMMON_NOT_FOUND;
+            case UNAUTHORIZED -> ErrorType.COMMON_UNAUTHORIZED;
             case BAD_REQUEST -> ErrorType.COMMON_INVALID_INPUT;
             case FORBIDDEN -> ErrorType.COMMON_FORBIDDEN;
             default -> ErrorType.COMMON_INTERNAL;
@@ -103,16 +143,21 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(body);
     }
 
-    private static Object safeRejectedValue(FieldError fe) {
-        Object v = fe.getRejectedValue();
-        if (v == null) return null;
-        String s = String.valueOf(v);
-        return s.length() > 200 ? s.substring(0, 200) + "..." : v;
-    }
-
-    /** 요청 추적용 ID(필요하면 필터에서 생성/주입, 지금은 헤더만 읽음) */
-    private static String requestId(HttpServletRequest req) {
-        String h = req.getHeader("X-Request-Id");
-        return (h != null && !h.isBlank()) ? h : null;
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiErrorResponse> handleUnreadable(HttpMessageNotReadableException e,
+        HttpServletRequest req) {
+        String path = req.getRequestURI();
+        // 로그인 요청이면 상세 노출 없이 401 고정
+        if (path != null && path.endsWith("/auth/login")) {
+            ApiErrorResponse body = ApiErrorResponse.of(
+                ErrorType.AUTH_INVALID_CREDENTIALS, null, path, requestId(req), null
+            );
+            return ResponseEntity.status(ErrorType.AUTH_INVALID_CREDENTIALS.httpStatus).body(body);
+        }
+        // 그 외는 400
+        ApiErrorResponse body = ApiErrorResponse.of(
+            ErrorType.COMMON_INVALID_INPUT, null, path, requestId(req), null
+        );
+        return ResponseEntity.status(ErrorType.COMMON_INVALID_INPUT.httpStatus).body(body);
     }
 }

--- a/src/main/java/io/routepickapi/dto/auth/LoginRequest.java
+++ b/src/main/java/io/routepickapi/dto/auth/LoginRequest.java
@@ -1,5 +1,6 @@
 package io.routepickapi.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
@@ -10,7 +11,8 @@ import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
     @Email @NotBlank String email,
-    @NotBlank String password
+    @NotBlank @Schema(type = "string", format = "password")
+    String password
 ) {
 
 }

--- a/src/main/java/io/routepickapi/dto/auth/LoginRequest.java
+++ b/src/main/java/io/routepickapi/dto/auth/LoginRequest.java
@@ -2,7 +2,6 @@ package io.routepickapi.dto.auth;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 
 /**
  * 로그인 요청 DTO
@@ -10,8 +9,8 @@ import jakarta.validation.constraints.Size;
  */
 
 public record LoginRequest(
-    @Email @NotBlank @Size(max = 255) String email,
-    @NotBlank @Size(min = 8, max = 72) String password
+    @Email @NotBlank String email,
+    @NotBlank String password
 ) {
 
 }

--- a/src/main/java/io/routepickapi/dto/auth/SignUpRequest.java
+++ b/src/main/java/io/routepickapi/dto/auth/SignUpRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
 public record SignUpRequest(
     @NotBlank @Email @Size(max = 255) String email,
     @NotBlank @Size(min = 8, max = 72)
-    @Pattern(regexp = "^\\S+$", message = "password는 공백을 포함할 수 없습니다.")
+    @Pattern(regexp = "^\\S+$", message = "password는 공백을 포함할 수 없습니다.") @Schema(type = "string", format = "password")
     String password,
     @NotBlank @Size(max = 40) String nickname
 ) {

--- a/src/main/java/io/routepickapi/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/io/routepickapi/security/JwtAuthenticationEntryPoint.java
@@ -1,22 +1,27 @@
 package io.routepickapi.security;
 
-import jakarta.servlet.ServletException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 /**
- * 401 Unauthorized
+ * 인증 필요 자원에 미인증 접근 시 401 Unauthorized JSON 본문 응답
  */
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper mapper; // Spring Boot 기본 ObjectMapper 주입
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException authException) throws IOException, ServletException {
+        AuthenticationException authException) throws IOException {
+
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write("{\"message\":\"Unauthorized\"}");

--- a/src/main/java/io/routepickapi/service/AuthService.java
+++ b/src/main/java/io/routepickapi/service/AuthService.java
@@ -1,5 +1,7 @@
 package io.routepickapi.service;
 
+import io.routepickapi.common.error.CustomException;
+import io.routepickapi.common.error.ErrorType;
 import io.routepickapi.dto.auth.LoginRequest;
 import io.routepickapi.dto.auth.LoginResponse;
 import io.routepickapi.dto.auth.SignUpRequest;
@@ -10,11 +12,9 @@ import io.routepickapi.repository.UserRepository;
 import io.routepickapi.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @Service
@@ -28,8 +28,9 @@ public class AuthService {
 
     // 회원가입
     public SignUpResponse signUp(SignUpRequest req) {
+        // 중복 이메일 409 CONFLICT
         if (userRepository.existsByEmail(req.email())) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "email already exists");
+            throw new CustomException(ErrorType.USER_EMAIL_EXISTS);
         }
 
         String hash = passwordEncoder.encode(req.password());
@@ -45,11 +46,11 @@ public class AuthService {
         // 1) ACTIVE 사용자만 로그인 허용
         User user = userRepository.findByEmailAndStatus(req.email(), UserStatus.ACTIVE)
             .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid credentials"));
+                () -> new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS));
 
-        // 2) 패스워드 매칭 (평문 vs 해시)
+        // 2) 패스워드 매칭 (평문 vs 해시) 불일치 -> 401
         if (!passwordEncoder.matches(req.password(), user.getPasswordHash())) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid credentials");
+            throw new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS);
         }
 
         // 3) 액세스 토큰 발급 (subject = userId, claim = email)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -29,3 +29,7 @@ jwt:
   secret: ${JWT_SECRET}
   access-ttl-seconds: 3600
   issuer: routepick
+
+logging:
+  level:
+    org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver: ERROR


### PR DESCRIPTION
### 통합 에러 응답 표준화(로그인 보안 메세지 포함)

**1) 전역 예외 처리 통합**

- GlobalExceptionHandler
  - CustomException → ErrorType 기반으로 상태/코드/메시지 통일 응답
  - MethodArgumentNotValidException(본문 검증), ConstraintViolationException(쿼리/경로) → 400 COMMON_INVALID_INPUT + 필드 상세(field, message, rejectedValue(마스킹))
  - ResponseStatusException → 상태코드 매핑: 400/401/403/404 표준 타입으로 변환
  - HttpMessageNotReadableException(JSON 파싱 실패) → 400
  - /auth/login 특수 처리: 위 모든 검증/파싱 실패도 **401 AUTH_INVALID_CREDENTIALS**로 통일, 필드 상세 미노출(보안)

**2) 에러 타입 확장**
- ErrorType 추가/정리
  - 공통: COMMON_UNAUTHORIZED, COMMON_CONFLICT, COMMON_RATE_LIMIT 등
  - 인증: AUTH_INVALID_CREDENTIALS, AUTH_TOKEN_INVALID, AUTH_TOKEN_EXPIRED
  - 도메인: USER_* / POST_* /  COMMENT_* 등