### PR TITLE
feat(users): add GET /users/me endpoint (authenticated user profile)

### DIFF
--- a/src/main/java/io/routepickapi/controller/UserController.java
+++ b/src/main/java/io/routepickapi/controller/UserController.java
@@ -1,0 +1,42 @@
+package io.routepickapi.controller;
+
+import io.routepickapi.common.error.CustomException;
+import io.routepickapi.common.error.ErrorType;
+import io.routepickapi.dto.user.MeResponse;
+import io.routepickapi.security.AuthUser;
+import io.routepickapi.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 내 정보 조회
+     * - SecurityConfig 에서 인증 필요로 보호 JwtAuthenticationFilter 가 SecurityContext 에 AuthUser 주입
+     */
+    @Operation(
+        summary = "내 정보 조회",
+        description = "현재 로그인한 사용자의 프로필 반환",
+        security = {@SecurityRequirement(name = "bearerAuth")} // OpenAPI: Bearer 필요
+    )
+    @GetMapping("/me")
+    public MeResponse me(@AuthenticationPrincipal AuthUser currentUser) {
+        if (currentUser == null) {
+            throw new CustomException(ErrorType.COMMON_UNAUTHORIZED);
+        }
+        log.debug("GET /users/me - userId={}", currentUser.id());
+        return userService.getMe(currentUser.id());
+    }
+}

--- a/src/main/java/io/routepickapi/dto/user/MeResponse.java
+++ b/src/main/java/io/routepickapi/dto/user/MeResponse.java
@@ -1,0 +1,28 @@
+package io.routepickapi.dto.user;
+
+import io.routepickapi.entity.user.User;
+import java.time.LocalDateTime;
+
+/**
+ * 로그인한 본인 정보 응답 DTO
+ * - 불필요한 내부 필드 노출 X
+ */
+public record MeResponse(
+    Long id,
+    String email,
+    String nickname,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+
+    // 엔티티 -> DTO 변환 (static factory method)
+    public static MeResponse from(User u) {
+        return new MeResponse(
+            u.getId(),
+            u.getEmail(),
+            u.getNickname(),
+            u.getCreatedAt(),
+            u.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/io/routepickapi/service/UserService.java
+++ b/src/main/java/io/routepickapi/service/UserService.java
@@ -1,0 +1,26 @@
+package io.routepickapi.service;
+
+import io.routepickapi.common.error.CustomException;
+import io.routepickapi.common.error.ErrorType;
+import io.routepickapi.dto.user.MeResponse;
+import io.routepickapi.entity.user.User;
+import io.routepickapi.entity.user.UserStatus;
+import io.routepickapi.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public MeResponse getMe(Long userId) {
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+        return MeResponse.from(user);
+    }
+
+}


### PR DESCRIPTION
## feat(user): 내 정보 조회 API(/users/me) 추가 (JWT 인증)

### 요약
- 로그인한 사용자의 기본 프로필을 반환하는 내 정보 조회 엔트포인트 추가
- JWT 인증 기반으로 SecurityContext의 AuthUser에서 userId 추출하여 조회
- 에러 응답은 전역 규칙(GlobalExceptionHandler + ErrorType)에 맞춰 통일
---
### 변경 사항
- **Controller**
  - UserController GET /users/me 
  - @AuthenticationPrincipal AuthUser 사용해 현재 사용자 식별
 
- **Service**
  - UserService getMe(Long userId) 추가 (읽기전용 트랜잭션) 
 
- **DTO**
  - MeResponse 추가: id, email, nickname, status, createdAt, updatedAt
 
- **보안**
  - SecurityConfig: 기본 정책에 의해 /users/**는 인증 필요(별도 변경 없음)

- **예외 처리**
  - 존재하지 않거나 비활성 사용자 → ErrorType.USER_NOT_FOUND (404)
  - 인증 실패/토큰 문제 →  JwtAuthenticationEntryPoint 통해 401