### PR TITLE
Feat/auth refresh redis

### DIFF
--- a/src/main/java/io/routepickapi/config/RedisConfig.java
+++ b/src/main/java/io/routepickapi/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package io.routepickapi.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +16,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class RedisConfig {
 
     private final RedisProperties redisProps;
@@ -51,5 +54,11 @@ public class RedisConfig {
         template.setHashValueSerializer(json);
         template.afterPropertiesSet();
         return template;
+    }
+
+    @PostConstruct
+    public void logRedisConn() {
+        log.info("Redis connect -> {}:{}, timeout={}", redisProps.getHost(), redisProps.getPort(),
+            redisProps.getTimeout());
     }
 }

--- a/src/main/java/io/routepickapi/controller/AuthController.java
+++ b/src/main/java/io/routepickapi/controller/AuthController.java
@@ -1,5 +1,6 @@
 package io.routepickapi.controller;
 
+import io.routepickapi.dto.IssuedTokens;
 import io.routepickapi.dto.auth.LoginRequest;
 import io.routepickapi.dto.auth.LoginResponse;
 import io.routepickapi.dto.auth.SignUpRequest;
@@ -8,8 +9,11 @@ import io.routepickapi.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class AuthController {
 
+    private static final String REFRESH_COOKIE = "RP_REFRESH"; // 쿠키 이름 (고정)
     private final AuthService authService;
 
     @Operation(summary = "회원가입", description = "이메일/비밀번호/닉네임 회원가입")
@@ -36,7 +41,23 @@ public class AuthController {
     @Operation(summary = "로그인", description = "이메일/비밀번호 로그인 -> JWT 발급")
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
-        LoginResponse res = authService.login(req);
-        return ResponseEntity.ok(res); // 200 OK, body 에 토큰/만료
+        // 1) 서비스에서 토큰들 발급 + Redis 저장
+        IssuedTokens tokens = authService.loginIssueTokens(req);
+
+        // 2) refresh 토큰을 httpOnly 쿠키로 설정
+        ResponseCookie reponseCookie = ResponseCookie.from(REFRESH_COOKIE, tokens.refreshToken())
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofSeconds(tokens.refreshTtlSec()))
+            .build();
+
+        // 3) 바디에는 access 토큰만
+        LoginResponse body = new LoginResponse(tokens.accessToken(), tokens.accessExpiresInSec());
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, reponseCookie.toString())
+            .body(body);
     }
 }

--- a/src/main/java/io/routepickapi/controller/AuthController.java
+++ b/src/main/java/io/routepickapi/controller/AuthController.java
@@ -1,5 +1,7 @@
 package io.routepickapi.controller;
 
+import io.routepickapi.common.error.CustomException;
+import io.routepickapi.common.error.ErrorType;
 import io.routepickapi.dto.IssuedTokens;
 import io.routepickapi.dto.auth.LoginRequest;
 import io.routepickapi.dto.auth.LoginResponse;
@@ -13,11 +15,14 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,7 +50,7 @@ public class AuthController {
         IssuedTokens tokens = authService.loginIssueTokens(req);
 
         // 2) refresh 토큰을 httpOnly 쿠키로 설정
-        ResponseCookie reponseCookie = ResponseCookie.from(REFRESH_COOKIE, tokens.refreshToken())
+        ResponseCookie responseCookie = ResponseCookie.from(REFRESH_COOKIE, tokens.refreshToken())
             .httpOnly(true)
             .secure(false)
             .sameSite("Lax")
@@ -57,7 +62,53 @@ public class AuthController {
         LoginResponse body = new LoginResponse(tokens.accessToken(), tokens.accessExpiresInSec());
 
         return ResponseEntity.ok()
-            .header(HttpHeaders.SET_COOKIE, reponseCookie.toString())
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
             .body(body);
+    }
+
+    @Operation(summary = "토큰 재발급", description = "HttpOnly 쿠키의 refresh 토큰으로 access 토큰 재발급")
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(
+        @CookieValue(name = REFRESH_COOKIE, required = false) String refreshCookie
+    ) {
+        if (refreshCookie == null || refreshCookie.isBlank()) {
+            // refresh 쿠키 없음 -> 401
+            throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
+        }
+        IssuedTokens tokens = authService.refresh(refreshCookie);
+
+        // 새 refresh 를 쿠키로 교체
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, tokens.refreshToken())
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofSeconds(tokens.refreshTtlSec()))
+            .build();
+
+        LoginResponse body = new LoginResponse(tokens.accessToken(), tokens.accessExpiresInSec());
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .body(body);
+    }
+
+    @Operation(summary = "로그아웃", description = "access 블랙리스트 등록 + refresh 제거 + 쿠키 제거")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+        @CookieValue(name = REFRESH_COOKIE, required = false) String refreshCookie,
+        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader) {
+        authService.logout(authHeader, refreshCookie);
+
+        ResponseCookie clear = ResponseCookie.from(REFRESH_COOKIE, "")
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ZERO)
+            .build();
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .header(HttpHeaders.SET_COOKIE, clear.toString())
+            .build();
     }
 }

--- a/src/main/java/io/routepickapi/controller/AuthController.java
+++ b/src/main/java/io/routepickapi/controller/AuthController.java
@@ -43,27 +43,31 @@ public class AuthController {
         return ResponseEntity.created(URI.create("/users/" + res.id())).body(res);
     }
 
+    // 공통 로직 통합 (refresh 쿠키 생성)
+    private ResponseCookie buildRefreshCookie(String value, long maxAgeSec) {
+        return ResponseCookie.from(REFRESH_COOKIE, value)
+            .httpOnly(true) // JS 접근 차단
+            .secure(false) // prod 는 true(HTTPS)로
+            .sameSite("Lax") // prod 에서 cross-site 필요하면 "None"
+            .path("/")
+            .maxAge(Duration.ofSeconds(maxAgeSec))
+            .build();
+    }
+
+    // 공통 로직 통합 (토큰응답 + 쿠키 헤더 세팅)
+    private ResponseEntity<LoginResponse> okWithRefresh(IssuedTokens t) {
+        ResponseCookie cookie = buildRefreshCookie(t.refreshToken(), t.accessExpiresInSec());
+        LoginResponse body = new LoginResponse(t.accessToken(), t.accessExpiresInSec());
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, cookie.toString())
+            .body(body);
+    }
+
     @Operation(summary = "로그인", description = "이메일/비밀번호 로그인 -> JWT 발급")
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
-        // 1) 서비스에서 토큰들 발급 + Redis 저장
         IssuedTokens tokens = authService.loginIssueTokens(req);
-
-        // 2) refresh 토큰을 httpOnly 쿠키로 설정
-        ResponseCookie responseCookie = ResponseCookie.from(REFRESH_COOKIE, tokens.refreshToken())
-            .httpOnly(true)
-            .secure(false)
-            .sameSite("Lax")
-            .path("/")
-            .maxAge(Duration.ofSeconds(tokens.refreshTtlSec()))
-            .build();
-
-        // 3) 바디에는 access 토큰만
-        LoginResponse body = new LoginResponse(tokens.accessToken(), tokens.accessExpiresInSec());
-
-        return ResponseEntity.ok()
-            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-            .body(body);
+        return okWithRefresh(tokens);
     }
 
     @Operation(summary = "토큰 재발급", description = "HttpOnly 쿠키의 refresh 토큰으로 access 토큰 재발급")
@@ -76,20 +80,7 @@ public class AuthController {
             throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
         }
         IssuedTokens tokens = authService.refresh(refreshCookie);
-
-        // 새 refresh 를 쿠키로 교체
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, tokens.refreshToken())
-            .httpOnly(true)
-            .secure(false)
-            .sameSite("Lax")
-            .path("/")
-            .maxAge(Duration.ofSeconds(tokens.refreshTtlSec()))
-            .build();
-
-        LoginResponse body = new LoginResponse(tokens.accessToken(), tokens.accessExpiresInSec());
-        return ResponseEntity.ok()
-            .header(HttpHeaders.SET_COOKIE, cookie.toString())
-            .body(body);
+        return okWithRefresh(tokens);
     }
 
     @Operation(summary = "로그아웃", description = "access 블랙리스트 등록 + refresh 제거 + 쿠키 제거")

--- a/src/main/java/io/routepickapi/controller/AuthController.java
+++ b/src/main/java/io/routepickapi/controller/AuthController.java
@@ -39,7 +39,10 @@ public class AuthController {
     @Operation(summary = "회원가입", description = "이메일/비밀번호/닉네임 회원가입")
     @PostMapping("/signup")
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest req) {
+        log.debug("POST /auth/signup - request received (email={}, nickname={})", req.email(),
+            req.nickname());
         SignUpResponse res = authService.signUp(req);
+        log.info("User signed up: id={}, email={}", res.id(), res.email());
         return ResponseEntity.created(URI.create("/users/" + res.id())).body(res);
     }
 
@@ -56,8 +59,11 @@ public class AuthController {
 
     // 공통 로직 통합 (토큰응답 + 쿠키 헤더 세팅)
     private ResponseEntity<LoginResponse> okWithRefresh(IssuedTokens t) {
-        ResponseCookie cookie = buildRefreshCookie(t.refreshToken(), t.accessExpiresInSec());
+        ResponseCookie cookie = buildRefreshCookie(t.refreshToken(), t.refreshTtlSec());
         LoginResponse body = new LoginResponse(t.accessToken(), t.accessExpiresInSec());
+
+        log.debug("Set refresh cookie (name={}, maxAgeSec={})", REFRESH_COOKIE, t.refreshTtlSec());
+        log.debug("Respond with access token (expiresInSec={})", t.accessExpiresInSec());
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, cookie.toString())
             .body(body);
@@ -66,7 +72,9 @@ public class AuthController {
     @Operation(summary = "로그인", description = "이메일/비밀번호 로그인 -> JWT 발급")
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
+        log.debug("POST /auth/login - request received (email={})", req.email());
         IssuedTokens tokens = authService.loginIssueTokens(req);
+        log.info("Login Success (email={})", req.email());
         return okWithRefresh(tokens);
     }
 
@@ -75,11 +83,15 @@ public class AuthController {
     public ResponseEntity<LoginResponse> refresh(
         @CookieValue(name = REFRESH_COOKIE, required = false) String refreshCookie
     ) {
+        log.debug("POST /auth/refresh - request received (hasCookie={})", refreshCookie != null);
         if (refreshCookie == null || refreshCookie.isBlank()) {
+            log.warn("Refresh failed: no refresh cookie");
             // refresh 쿠키 없음 -> 401
             throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
         }
         IssuedTokens tokens = authService.refresh(refreshCookie);
+        log.info("Refresh success (new access expSec={}, new refresh ttlSec={})",
+            tokens.accessExpiresInSec(), tokens.refreshTtlSec());
         return okWithRefresh(tokens);
     }
 
@@ -87,7 +99,10 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(
         @CookieValue(name = REFRESH_COOKIE, required = false) String refreshCookie,
-        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader) {
+        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader
+    ) {
+        log.debug("POST /auth/logout - request received (hasAuthHeader={}, hasRefreshCookie={})",
+            authHeader != null, refreshCookie != null);
         authService.logout(authHeader, refreshCookie);
 
         ResponseCookie clear = ResponseCookie.from(REFRESH_COOKIE, "")
@@ -98,6 +113,7 @@ public class AuthController {
             .maxAge(Duration.ZERO)
             .build();
 
+        log.info("Logout success (Refresh cookie cleared)");
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .header(HttpHeaders.SET_COOKIE, clear.toString())
             .build();

--- a/src/main/java/io/routepickapi/dto/IssuedTokens.java
+++ b/src/main/java/io/routepickapi/dto/IssuedTokens.java
@@ -1,0 +1,15 @@
+package io.routepickapi.dto;
+
+/**
+ * 로그인 시 서버 내부에서만 쓰는 발급 결과 DTO
+ * - refreshToken 은 응답 바디에 담지 않고, 컨트롤러에서 쿠키로 내려보냄
+ */
+public record IssuedTokens(
+    String accessToken,        // 액세스 토큰
+    long accessExpiresInSec,   // 액세스 만료(초)
+    String refreshToken,       // 리프레시 토큰 (쿠키로 전송)
+    long refreshTtlSec,        // 리프레시 TTL(초)
+    String refreshTokenId      // Redis 저장 인덱싱용 토큰 ID(tid)
+) {
+
+}

--- a/src/main/java/io/routepickapi/security/jwt/JwtProvider.java
+++ b/src/main/java/io/routepickapi/security/jwt/JwtProvider.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.security.SecurityException;
 import io.routepickapi.config.JwtProperties;
 import jakarta.annotation.PostConstruct;
 import java.util.Date;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,12 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+
+/**
+ * JWT 발급/검증/파싱 전담 컴포넌트
+ * - access: subject=userId, claim=email
+ * - refresh: subject=userId, claim=tid(토큰 ID), typ=refresh
+ */
 public class JwtProvider {
 
     private final JwtProperties props;
@@ -38,9 +45,6 @@ public class JwtProvider {
 
     /**
      * 액세스 토큰 발급
-     *
-     * @Param userId 내부 PK
-     * @Param email 보조 클레임
      */
     public String generateAccessToken(Long userId, String email) {
         long now = System.currentTimeMillis();
@@ -53,6 +57,32 @@ public class JwtProvider {
             .issuedAt(iat)
             .expiration(exp)
             .claim("email", email)
+            .signWith(secretKey)
+            .compact();
+    }
+
+    /**
+     * 리프레시 토큰용 랜덤 토큰 ID 생성 (JTI 대응)
+     */
+    public String newTokenId() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * 리프레시 토큰 발급: typ=refresh, tid=토큰 ID 포함
+     */
+    public String generateRefreshToken(Long userId, String tokenId) {
+        long now = System.currentTimeMillis();
+        Date iat = new Date(now);
+        Date exp = new Date(now + props.getRefreshTtlSeconds() * 1000);
+
+        return Jwts.builder()
+            .issuer(props.getIssuer())
+            .subject(String.valueOf(userId))
+            .issuedAt(iat)
+            .expiration(exp)
+            .claim("typ", "refresh")
+            .claim("tid", tokenId)
             .signWith(secretKey)
             .compact();
     }
@@ -72,6 +102,19 @@ public class JwtProvider {
             log.debug("비어있거나 손상된 JWT.", e);
         }
         return false;
+    }
+
+    /**
+     * refresh 전용: typ=refresh 인지 빠르게 확인(옵션)
+     */
+    public boolean isRefreshToken(String token) {
+        try {
+            String typ = Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token).getPayload().get("typ", String.class);
+            return "refresh".equals(typ);
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     // 토큰에서 userId(sub) 추출

--- a/src/main/java/io/routepickapi/security/jwt/JwtProvider.java
+++ b/src/main/java/io/routepickapi/security/jwt/JwtProvider.java
@@ -142,4 +142,11 @@ public class JwtProvider {
             .getExpiration();
         return exp.getTime() - System.currentTimeMillis();
     }
+
+    public String getTokenId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get("tid", String.class); // refresh 토큰에 들어있는 토큰 ID
+    }
 }

--- a/src/main/java/io/routepickapi/service/AccessTokenBlacklistService.java
+++ b/src/main/java/io/routepickapi/service/AccessTokenBlacklistService.java
@@ -6,6 +6,7 @@ import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HexFormat;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class AccessTokenBlacklistService {
 
     private static final HexFormat HEX = HexFormat.of(); // 소문자 hex(기본)
@@ -31,12 +33,14 @@ public class AccessTokenBlacklistService {
 
     public void blacklist(String accessToken, long ttlMillis) {
         if (ttlMillis <= 0L) {
+            log.debug("Blacklist skipped (ttl<=0)");
             return;
         }
 
         String tokenHash = sha256Hex(accessToken);
         Duration ttl = Duration.ofMillis(ttlMillis);
         redis.opsForValue().set(key(tokenHash), "1", ttl);
+        log.info("Blacklisted access token: key={}, ttlMs={}", key(tokenHash), ttlMillis);
     }
 
     public boolean isBlacklisted(String accessToken) {

--- a/src/main/java/io/routepickapi/service/AuthService.java
+++ b/src/main/java/io/routepickapi/service/AuthService.java
@@ -27,6 +27,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService; // Redis Store
+    private final AccessTokenBlacklistService blacklistService;
 
     // 회원가입
     public SignUpResponse signUp(SignUpRequest req) {
@@ -82,5 +83,57 @@ public class AuthService {
     public LoginResponse login(LoginRequest req) {
         IssuedTokens t = loginIssueTokens(req);
         return new LoginResponse(t.accessToken(), t.accessExpiresInSec());
+    }
+
+    public IssuedTokens refresh(String refreshToken) {
+        // 1) 형식/서명/만료 검증 + refresh 타입 확인
+        if (!jwtProvider.validate(refreshToken) || !jwtProvider.isRefreshToken(refreshToken)) {
+            throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
+        }
+
+        Long userId = jwtProvider.getUserId(refreshToken);
+        String oldTid = jwtProvider.getTokenId(refreshToken);
+
+        // 2) Redis 에 실제 보관중인지 확인 (도난/재사용 방지)
+        String stored = refreshTokenService.get(userId, oldTid);
+        if (stored == null || !stored.equals(refreshToken)) {
+            throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
+        }
+
+        // 3) 새 Access 발급
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+            .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+
+        String newAccess = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        long accessExpSec = jwtProvider.getRemainingMillis(newAccess) / 1000;
+
+        // 4) refresh 토큰 회전: 새 tid/refresh 발급 + Redis 교체
+        String newTid = jwtProvider.newTokenId();
+        String newRefresh = jwtProvider.generateRefreshToken(userId, newTid);
+        long refreshTtlSec = jwtProvider.getRemainingMillis(newRefresh) / 1000;
+
+        refreshTokenService.delete(userId, oldTid);
+        refreshTokenService.save(userId, newTid, newRefresh);
+
+        return new IssuedTokens(newAccess, accessExpSec, newRefresh, refreshTtlSec, newTid);
+    }
+
+    public void logout(String accessHeader, String refreshCookie) {
+        // 1) access 블랙리스트 등록
+        if (accessHeader != null && accessHeader.regionMatches(true, 0, "Bearer ", 0, 7)) {
+            String at = accessHeader.substring(7).trim();
+            if (!at.isEmpty() && jwtProvider.validate(at)) {
+                long ttlMs = jwtProvider.getRemainingMillis(at);
+                blacklistService.blacklist(at, ttlMs);
+            }
+        }
+
+        // 2) refresh 삭제
+        if (refreshCookie != null && !refreshCookie.isBlank() && jwtProvider.validate(refreshCookie)
+            && jwtProvider.isRefreshToken(refreshCookie)) {
+            Long uid = jwtProvider.getUserId(refreshCookie);
+            String tid = jwtProvider.getTokenId(refreshCookie);
+            refreshTokenService.delete(uid, tid);
+        }
     }
 }

--- a/src/main/java/io/routepickapi/service/AuthService.java
+++ b/src/main/java/io/routepickapi/service/AuthService.java
@@ -2,6 +2,7 @@ package io.routepickapi.service;
 
 import io.routepickapi.common.error.CustomException;
 import io.routepickapi.common.error.ErrorType;
+import io.routepickapi.dto.IssuedTokens;
 import io.routepickapi.dto.auth.LoginRequest;
 import io.routepickapi.dto.auth.LoginResponse;
 import io.routepickapi.dto.auth.SignUpRequest;
@@ -25,6 +26,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService; // Redis Store
 
     // 회원가입
     public SignUpResponse signUp(SignUpRequest req) {
@@ -41,25 +43,44 @@ public class AuthService {
         return new SignUpResponse(id, user.getEmail(), user.getNickname());
     }
 
-    // 로그인: 이메일로 유저 조회 -> 패스워드 매칭 -> JWT 발급
-    public LoginResponse login(LoginRequest req) {
-        // 1) ACTIVE 사용자만 로그인 허용
+    /**
+     * 로그인: 이메일/비번 검증 → access & refresh 동시 발급
+     * - refresh 는 Redis 에 저장하고, 컨트롤러가 HttpOnly 쿠키로 내려줌
+     */
+    public IssuedTokens loginIssueTokens(LoginRequest req) {
+        // 1) ACTIVE 사용자만 허용
         User user = userRepository.findByEmailAndStatus(req.email(), UserStatus.ACTIVE)
-            .orElseThrow(
-                () -> new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS));
+            .orElseThrow(() -> new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS));
 
-        // 2) 패스워드 매칭 (평문 vs 해시) 불일치 -> 401
+        // 2) 비밀번호 매칭
         if (!passwordEncoder.matches(req.password(), user.getPasswordHash())) {
             throw new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS);
         }
 
-        // 3) 액세스 토큰 발급 (subject = userId, claim = email)
-        String token = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        // 3) 액세스 토큰 발급
+        String accessToken = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
+        long accessExpiresInSec = jwtProvider.getRemainingMillis(accessToken) / 1000;
 
-        // 4) 남은 유효시간(초) 계산 후 응답
-        long expiresInSec = jwtProvider.getRemainingMillis(token) / 1000;
+        // 4) 리프레시 토큰 발급 (토큰 ID 포함) + Redis 저장
+        String tokenId = jwtProvider.newTokenId();
+        String refreshToken = jwtProvider.generateRefreshToken(user.getId(), tokenId);
+        long refreshTtlSec = jwtProvider.getRemainingMillis(refreshToken) / 1000;
+        refreshTokenService.save(user.getId(), tokenId, refreshToken);
 
         log.info("User logged in: id={}, email={}", user.getId(), user.getEmail());
-        return new LoginResponse(token, expiresInSec);
+        return new IssuedTokens(
+            accessToken,
+            accessExpiresInSec,
+            refreshToken,
+            refreshTtlSec,
+            tokenId
+        );
+    }
+
+    // 호환용 래퍼(임시: 바디엔 access만, refresh는 컨트롤러에서 쿠키로 세팅
+    @Deprecated // FE/테스트 정리 후 삭제 예정
+    public LoginResponse login(LoginRequest req) {
+        IssuedTokens t = loginIssueTokens(req);
+        return new LoginResponse(t.accessToken(), t.accessExpiresInSec());
     }
 }

--- a/src/main/java/io/routepickapi/service/AuthService.java
+++ b/src/main/java/io/routepickapi/service/AuthService.java
@@ -31,8 +31,10 @@ public class AuthService {
 
     // 회원가입
     public SignUpResponse signUp(SignUpRequest req) {
+        log.debug("SignUp requested (email={}, nickname={})", req.email(), req.nickname());
         // 중복 이메일 409 CONFLICT
         if (userRepository.existsByEmail(req.email())) {
+            log.warn("SignUp failed: email already exists (email={})", req.email());
             throw new CustomException(ErrorType.USER_EMAIL_EXISTS);
         }
 
@@ -40,7 +42,7 @@ public class AuthService {
         User user = new User(req.email(), hash, req.nickname());
         Long id = userRepository.save(user).getId();
 
-        log.info("User signed up: id={}, email={}", id, user.getEmail());
+        log.info("SignUp success: id={}, email={}", id, user.getEmail());
         return new SignUpResponse(id, user.getEmail(), user.getNickname());
     }
 
@@ -49,12 +51,17 @@ public class AuthService {
      * - refresh 는 Redis 에 저장하고, 컨트롤러가 HttpOnly 쿠키로 내려줌
      */
     public IssuedTokens loginIssueTokens(LoginRequest req) {
+        log.debug("Login requested (email={})", req.email());
         // 1) ACTIVE 사용자만 허용
         User user = userRepository.findByEmailAndStatus(req.email(), UserStatus.ACTIVE)
-            .orElseThrow(() -> new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS));
+            .orElseThrow(() -> {
+                log.warn("Login failed: user not found or inactive (email={})", req.email());
+                return new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS);
+            });
 
         // 2) 비밀번호 매칭
         if (!passwordEncoder.matches(req.password(), user.getPasswordHash())) {
+            log.warn("Login failed: wrong password (email={})", req.email());
             throw new CustomException(ErrorType.AUTH_INVALID_CREDENTIALS);
         }
 
@@ -68,7 +75,7 @@ public class AuthService {
         long refreshTtlSec = jwtProvider.getRemainingMillis(refreshToken) / 1000;
         refreshTokenService.save(user.getId(), tokenId, refreshToken);
 
-        log.info("User logged in: id={}, email={}", user.getId(), user.getEmail());
+        log.info("Login success: id={}, email={}, tid={}", user.getId(), user.getEmail(), tokenId);
         return new IssuedTokens(
             accessToken,
             accessExpiresInSec,
@@ -78,7 +85,7 @@ public class AuthService {
         );
     }
 
-    // 호환용 래퍼(임시: 바디엔 access만, refresh는 컨트롤러에서 쿠키로 세팅
+    // 호환용 래퍼(임시: 바디엔 access 만, refresh 는 컨트롤러에서 쿠키로 세팅
     @Deprecated // FE/테스트 정리 후 삭제 예정
     public LoginResponse login(LoginRequest req) {
         IssuedTokens t = loginIssueTokens(req);
@@ -86,8 +93,10 @@ public class AuthService {
     }
 
     public IssuedTokens refresh(String refreshToken) {
+        log.debug("Refresh requested");
         // 1) 형식/서명/만료 검증 + refresh 타입 확인
         if (!jwtProvider.validate(refreshToken) || !jwtProvider.isRefreshToken(refreshToken)) {
+            log.warn("Refresh failed: invalid or non-refresh token");
             throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
         }
 
@@ -97,12 +106,17 @@ public class AuthService {
         // 2) Redis 에 실제 보관중인지 확인 (도난/재사용 방지)
         String stored = refreshTokenService.get(userId, oldTid);
         if (stored == null || !stored.equals(refreshToken)) {
+            log.warn("Refresh failed: token not stored or mismatched (userId={}, tid={})", userId,
+                oldTid);
             throw new CustomException(ErrorType.AUTH_TOKEN_INVALID);
         }
 
         // 3) 새 Access 발급
         User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
-            .orElseThrow(() -> new CustomException(ErrorType.USER_NOT_FOUND));
+            .orElseThrow(() -> {
+                log.warn("Refresh failed: user not active (userId={})", userId);
+                return new CustomException(ErrorType.USER_NOT_FOUND);
+            });
 
         String newAccess = jwtProvider.generateAccessToken(user.getId(), user.getEmail());
         long accessExpSec = jwtProvider.getRemainingMillis(newAccess) / 1000;
@@ -115,25 +129,40 @@ public class AuthService {
         refreshTokenService.delete(userId, oldTid);
         refreshTokenService.save(userId, newTid, newRefresh);
 
+        log.info("Refresh success: userId={}, newTid={}, accessExpSec={}, refreshTtlSec={}", userId,
+            newTid, accessExpSec, refreshTtlSec);
         return new IssuedTokens(newAccess, accessExpSec, newRefresh, refreshTtlSec, newTid);
     }
 
     public void logout(String accessHeader, String refreshCookie) {
+        boolean hasAccess =
+            accessHeader != null && accessHeader.regionMatches(true, 0, "Bearer ", 0, 7);
+        boolean hasRefresh = refreshCookie != null && !refreshCookie.isBlank();
+        log.debug("Logout requested (hasAccessHeader={}, hasRefreshCookie={})", hasAccess,
+            hasRefresh);
+
         // 1) access 블랙리스트 등록
-        if (accessHeader != null && accessHeader.regionMatches(true, 0, "Bearer ", 0, 7)) {
+        if (hasAccess) {
             String at = accessHeader.substring(7).trim();
             if (!at.isEmpty() && jwtProvider.validate(at)) {
                 long ttlMs = jwtProvider.getRemainingMillis(at);
                 blacklistService.blacklist(at, ttlMs);
+                log.info("Access token blacklisted (ttlMs={})", ttlMs);
+            } else {
+                log.debug("Skip blacklist: invalid or empty access token");
             }
         }
 
-        // 2) refresh 삭제
-        if (refreshCookie != null && !refreshCookie.isBlank() && jwtProvider.validate(refreshCookie)
+        // 2) refresh token 삭제
+        if (hasRefresh && jwtProvider.validate(refreshCookie)
             && jwtProvider.isRefreshToken(refreshCookie)) {
             Long uid = jwtProvider.getUserId(refreshCookie);
             String tid = jwtProvider.getTokenId(refreshCookie);
             refreshTokenService.delete(uid, tid);
+            log.info("Refresh token deleted (userId={}, tid={})", uid, tid);
+        } else if (hasRefresh) {
+            log.debug("Skip refresh delete: invalid or non-refresh token");
         }
+        log.info("Logout completed");
     }
 }

--- a/src/main/java/io/routepickapi/service/RefreshTokenService.java
+++ b/src/main/java/io/routepickapi/service/RefreshTokenService.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class RefreshTokenService {
 
     private final StringRedisTemplate redis;
@@ -33,8 +35,10 @@ public class RefreshTokenService {
     // 저장 rt:{userId}:{tokenId} = token (TTL 부여) + 인덱스 세트에 tokenId 추가
     public void save(long userId, String tokenId, String refreshToken) {
         Duration ttl = Duration.ofSeconds(jwtProps.getRefreshTtlSeconds());
+        String k = key(userId, tokenId);
         redis.opsForValue().set(key(userId, tokenId), refreshToken, ttl);
         redis.opsForSet().add(indexKey(userId), tokenId);
+        log.info("RT Save -> key={}, ttlSec={}", k, ttl.toSeconds());
     }
 
     // 단건 조회(검증용)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
       ddl-auto: validate # 스키마는 Flyway가 책임지고, JPA는 검증만.
     open-in-view: false
     properties:
-      hibernate.hibernate.format_sql: true
+      hibernate.format_sql: true
 
   data:
     redis:


### PR DESCRIPTION
## 요약
- **JWT 리프레시 토큰** 발급/회전 추가 (`typ=refresh`, `tid` 포함)
- **HttpOnly 쿠키**로 refresh 전달 (`RP_REFRESH`)
- **Redis** 기반 저장소 도입
  - `rt:{userId}:{tokenId}` → refresh 토큰 저장 (TTL=14d)
  - `rtidx:{userId}` → 해당 유저의 refresh 토큰 ID 인덱스(Set)
  - `bl:at:{sha256(access)}` → access 블랙리스트(남은 만료시간만큼 TTL)
- **/auth API**
  - `POST /auth/login` : access 바디 + refresh 쿠키 세팅
  - `POST /auth/refresh` : 쿠키 기반 재발급(회전)
  - `POST /auth/logout` : access 블랙리스트 등록 + refresh 폐기 + 쿠키 삭제
- **JWT**
  - `JwtProvider`에 refresh 발급/파싱/검증 추가, 남은 만료시간 계산 지원
  - `JwtAuthenticationFilter`에 **블랙리스트 체크** 추가
- **로깅/보안**
  - 컨트롤러/서비스 주요 지점 로깅
  - 로그인 검증 오류는 401 + 상세 미노출 유지

## 변경 파일 (핵심)
- `AuthController`, `AuthService`
- `JwtProvider`, `JwtAuthenticationFilter`
- `RefreshTokenService`, `AccessTokenBlacklistService`
- `RedisConfig`, `application-dev.yml`, `docker-compose.yml`
- (이전 작업) `GlobalExceptionHandler` 로그인 경로 특수 처리

## 동작 확인 (로컬)
> 사전: `docker compose up -d redis` 후 애플리케이션 `dev` 프로필로 실행

```bash
# 1) 로그인 (refresh 쿠키 + access 바디)
curl -i -c cookies.txt \
  -X POST http://localhost:8080/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test2@example.com","password":"1234567890"}'

# access 변수에 토큰 저장 후 보호 API 호출 테스트
ACCESS="...복사한 access 토큰..."
curl -i http://localhost:8080/users/me -H "Authorization: Bearer $ACCESS"

# 2) refresh 재발급 (쿠키 사용, access 회전/갱신 + refresh 쿠키 교체)
curl -i -b cookies.txt -c cookies.txt -X POST http://localhost:8080/auth/refresh

# 3) 로그아웃 (access 블랙리스트 + refresh 폐기 + 쿠키 삭제)
curl -i -b cookies.txt -H "Authorization: Bearer $ACCESS" -X POST http://localhost:8080/auth/logout

# 4) 블랙리스트 검증: 같은 access로 다시 호출 시 401
curl -i http://localhost:8080/users/me -H "Authorization: Bearer $ACCESS"