### PR TITLE
feat(auth): 세션 관리 API 추가 + Logout All (Redis refresh/블랙리스트 연동)

### DIFF
--- a/src/main/java/io/routepickapi/controller/AuthController.java
+++ b/src/main/java/io/routepickapi/controller/AuthController.java
@@ -5,14 +5,17 @@ import io.routepickapi.common.error.ErrorType;
 import io.routepickapi.dto.IssuedTokens;
 import io.routepickapi.dto.auth.LoginRequest;
 import io.routepickapi.dto.auth.LoginResponse;
+import io.routepickapi.dto.auth.SessionInfoResponse;
 import io.routepickapi.dto.auth.SignUpRequest;
 import io.routepickapi.dto.auth.SignUpResponse;
 import io.routepickapi.security.AuthUser;
 import io.routepickapi.service.AuthService;
+import io.routepickapi.service.SessionService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -23,6 +26,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -38,6 +44,7 @@ public class AuthController {
 
     private static final String REFRESH_COOKIE = "RP_REFRESH"; // 쿠키 이름 (고정)
     private final AuthService authService;
+    private final SessionService sessionService;
 
     // 공통 로직 통합 (refresh 쿠키 생성)
     private ResponseCookie buildRefreshCookie(String value, long maxAgeSec) {
@@ -150,5 +157,30 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .header(HttpHeaders.SET_COOKIE, clear.toString())
             .build();
+    }
+
+    @Operation(summary = "내 세션 목록", description = "현재 계정의 활성 refresh 세션 목록을 최신순으로 반환")
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/sessions/")
+    public ResponseEntity<List<SessionInfoResponse>> listSessions(
+        @AuthenticationPrincipal AuthUser me
+    ) {
+        log.debug("GET /auth/sessions - userId={}", me.id());
+        List<SessionInfoResponse> res = sessionService.listSessions(me.id());
+        log.info("Sessions listed (userId={}, count={})", me.id(), res.size());
+        return ResponseEntity.ok(res);
+    }
+
+    @Operation(summary = "특정 세션 철회", description = "tid로 지정한 refresh 세션(다른기기 포함) 철회")
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/sessions/{tid}")
+    public ResponseEntity<Void> revokeSession(
+        @AuthenticationPrincipal AuthUser me,
+        @PathVariable("tid") String tid
+    ) {
+        log.debug("DELETE /auth/sessions/{tid} - userId={}, tid={}", me.id(), tid);
+        sessionService.revokeSession(me.id(), tid);
+        log.info("Session revoke success (userId={}, tid={})", me.id(), tid);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/io/routepickapi/controller/AuthController.java
+++ b/src/main/java/io/routepickapi/controller/AuthController.java
@@ -7,6 +7,7 @@ import io.routepickapi.dto.auth.LoginRequest;
 import io.routepickapi.dto.auth.LoginResponse;
 import io.routepickapi.dto.auth.SignUpRequest;
 import io.routepickapi.dto.auth.SignUpResponse;
+import io.routepickapi.security.AuthUser;
 import io.routepickapi.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -18,6 +19,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -35,16 +38,6 @@ public class AuthController {
 
     private static final String REFRESH_COOKIE = "RP_REFRESH"; // 쿠키 이름 (고정)
     private final AuthService authService;
-
-    @Operation(summary = "회원가입", description = "이메일/비밀번호/닉네임 회원가입")
-    @PostMapping("/signup")
-    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest req) {
-        log.debug("POST /auth/signup - request received (email={}, nickname={})", req.email(),
-            req.nickname());
-        SignUpResponse res = authService.signUp(req);
-        log.info("User signed up: id={}, email={}", res.id(), res.email());
-        return ResponseEntity.created(URI.create("/users/" + res.id())).body(res);
-    }
 
     // 공통 로직 통합 (refresh 쿠키 생성)
     private ResponseCookie buildRefreshCookie(String value, long maxAgeSec) {
@@ -67,6 +60,27 @@ public class AuthController {
         return ResponseEntity.ok()
             .header(HttpHeaders.SET_COOKIE, cookie.toString())
             .body(body);
+    }
+
+    // 쿠키 삭제 로직
+    private ResponseCookie clearRefreshCookie() {
+        return ResponseCookie.from(REFRESH_COOKIE, "")
+            .httpOnly(true)
+            .secure(false)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ZERO)
+            .build();
+    }
+
+    @Operation(summary = "회원가입", description = "이메일/비밀번호/닉네임 회원가입")
+    @PostMapping("/signup")
+    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest req) {
+        log.debug("POST /auth/signup - request received (email={}, nickname={})", req.email(),
+            req.nickname());
+        SignUpResponse res = authService.signUp(req);
+        log.info("User signed up: id={}, email={}", res.id(), res.email());
+        return ResponseEntity.created(URI.create("/users/" + res.id())).body(res);
     }
 
     @Operation(summary = "로그인", description = "이메일/비밀번호 로그인 -> JWT 발급")
@@ -114,6 +128,25 @@ public class AuthController {
             .build();
 
         log.info("Logout success (Refresh cookie cleared)");
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .header(HttpHeaders.SET_COOKIE, clear.toString())
+            .build();
+    }
+
+    @Operation(summary = "모든 기기에서 로그아웃", description = "현재 access 블랙리스트 + 사용자 모든 refresh 토큰 폐기 + 쿠키 삭제")
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/logout-all")
+    public ResponseEntity<Void> logoutAll(
+        @AuthenticationPrincipal AuthUser me,
+        @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader
+    ) {
+        log.debug("POST /auth/logout-all - request received (userId={}, hasAuthHeader={})", me.id(),
+            authHeader != null);
+
+        authService.logoutAll(authHeader, me.id());
+
+        ResponseCookie clear = clearRefreshCookie();
+        log.info("Logout-all success (userId={}, refresh cookie cleared)", me.id());
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .header(HttpHeaders.SET_COOKIE, clear.toString())
             .build();

--- a/src/main/java/io/routepickapi/dto/auth/SessionInfoResponse.java
+++ b/src/main/java/io/routepickapi/dto/auth/SessionInfoResponse.java
@@ -1,0 +1,10 @@
+package io.routepickapi.dto.auth;
+
+public record SessionInfoResponse(
+    String tokenId,
+    long issuedAtEpochSec,
+    long expiresAtEpochSec,
+    long ttlSec
+) {
+
+}

--- a/src/main/java/io/routepickapi/security/jwt/JwtProvider.java
+++ b/src/main/java/io/routepickapi/security/jwt/JwtProvider.java
@@ -149,4 +149,20 @@ public class JwtProvider {
             .getPayload()
             .get("tid", String.class); // refresh 토큰에 들어있는 토큰 ID
     }
+
+    // 토큰에서 iat(발급시각) 반환
+    public Date getIssuedAt(String token) {
+        return Jwts.parser().verifyWith(secretKey).build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getIssuedAt();
+    }
+
+    // 토큰에서 exp(만료시각) 반환
+    public Date getExpiration(String token) {
+        return Jwts.parser().verifyWith(secretKey).build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getExpiration();
+    }
 }

--- a/src/main/java/io/routepickapi/service/AuthService.java
+++ b/src/main/java/io/routepickapi/service/AuthService.java
@@ -165,4 +165,26 @@ public class AuthService {
         }
         log.info("Logout completed");
     }
+
+    public void logoutAll(String accessHeader, long userId) {
+        boolean hasAccess =
+            accessHeader != null && accessHeader.regionMatches(true, 0, "Bearer ", 0, 7);
+        log.debug("Logout ALL requested (userId={}, hasAccessHeader={})", userId, hasAccess);
+
+        // 1) access 블랙리스트
+        if (hasAccess) {
+            String at = accessHeader.substring(7).trim();
+            if (!at.isEmpty() && jwtProvider.validate(at)) {
+                long ttlMs = jwtProvider.getRemainingMillis(at);
+                blacklistService.blacklist(at, ttlMs);
+                log.info("Access token blacklisted for logout-all (ttlMs={})", ttlMs);
+            } else {
+                log.debug("Skip blacklist in logout-all: invalid/empty access");
+            }
+        }
+
+        // 2) 해당 유저의 모든 refresh 폐기
+        refreshTokenService.deleteAllForUser(userId);
+        log.info("All refresh tokens deleted (userId={})", userId);
+    }
 }

--- a/src/main/java/io/routepickapi/service/RefreshTokenService.java
+++ b/src/main/java/io/routepickapi/service/RefreshTokenService.java
@@ -61,4 +61,14 @@ public class RefreshTokenService {
         }
         redis.delete(indexKey(userId));
     }
+
+    // 유저의 refresh 토큰 ID 목록(rtidx:{userId} 세트 멤버들)
+    public Set<String> tokenIds(long userId) {
+        return redis.opsForSet().members(indexKey(userId));
+    }
+
+    // 인덱스 세트에서 특정 tokenId 제거(실제 값 키가 사라졌을 때 청소용)
+    public void removeIndex(long userId, String tokenId) {
+        redis.opsForSet().remove(indexKey(userId), tokenId);
+    }
 }

--- a/src/main/java/io/routepickapi/service/SessionService.java
+++ b/src/main/java/io/routepickapi/service/SessionService.java
@@ -1,0 +1,62 @@
+package io.routepickapi.service;
+
+import io.routepickapi.dto.auth.SessionInfoResponse;
+import io.routepickapi.security.jwt.JwtProvider;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtProvider jwtProvider;
+
+    public List<SessionInfoResponse> listSessions(long userId) {
+        Set<String> ids = refreshTokenService.tokenIds(userId);
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+
+        List<SessionInfoResponse> out = new ArrayList<>();
+
+        for (String tid : ids) {
+            String token = refreshTokenService.get(userId, tid);
+            if (token == null) {
+                // 값이 없는데 인덱스만 남은 고아 상태 -> 청소
+                refreshTokenService.removeIndex(userId, tid);
+                log.debug("Orphan tid removed from index (userId={}, tid={})", userId, tid);
+                continue;
+            }
+
+            Date iat = jwtProvider.getIssuedAt(token);
+            Date exp = jwtProvider.getExpiration(token);
+            long ttlSec = Math.max(0L, jwtProvider.getRemainingMillis(token) / 1000);
+
+            long iatSec = (iat != null ? iat.getTime() / 1000 : 0L);
+            long expSec = (exp != null ? exp.getTime() / 1000 : 0L);
+
+            out.add(new SessionInfoResponse(tid, iatSec, expSec, ttlSec));
+        }
+
+        // 만료시간 내림차순으로 정렬(가장 오래 남은 세션이 위로)
+        out.sort(Comparator.comparingLong(SessionInfoResponse::expiresAtEpochSec).reversed());
+        return out;
+    }
+
+    /**
+     * 현재 사용자(userId)의 특정 tid 세션 삭제 존재하지 않아도 에러 없이 통과 (멱등성)
+     */
+    public void revokeSession(long userId, String tokenId) {
+        // 실제 값 삭제 + 인덱스에서 제거 (값이 없어도 remove는 안전)
+        refreshTokenService.delete(userId, tokenId);
+        log.info("Session revoked (userid-{}, tid={})", userId, tokenId);
+    }
+}


### PR DESCRIPTION
## Summary
인증 플로우
- 활성 refresh 세션 조회/철회(기기별 로그아웃)
- 모든 기기 로그아웃(logout-all)
- access 블랙리스트 + refresh 회전/폐기 연동

## Endpoints
- GET    /auth/sessions              : 현재 계정의 활성 refresh 세션 목록 조회
- DELETE /auth/sessions/{tid}        : 특정 세션(tid) 철회
- POST   /auth/logout-all            : 현재 access 블랙리스트 + 모든 refresh 세션 폐기

> 기존 로그인/리프레시/로그아웃 API는 그대로 유지

## Changes
- `AuthController`
  - 위 3개 엔드포인트 추가
  - 공통 쿠키 빌더/클리어 메서드, 로그 보강
- `SessionService`
  - `listSessions(userId)`: rtidx:{userId} 기반 세션 스캔/정렬/고아 인덱스 청소
  - `revokeSession(userId, tokenId)`: 특정 세션 철회(멱등)
- `AuthService`
  - `logoutAll(authHeader, userId)`: access 블랙리스트 + 유저 refresh 전량 폐기
  - 로그인/리프레시/로그아웃 흐름 로그 보강
- `RefreshTokenService`
  - `tokenIds(userId)`, `removeIndex(userId, tid)` 헬퍼 추가
- `JwtProvider`
  - `getIssuedAt()`, `getExpiration()`, `getTokenId()` 공개

## Redis Keying
- Refresh 저장: `rt:{userId}:{tid}` = refreshToken (TTL=refreshTTL)
- 인덱스: `rtidx:{userId}` = {tid, ...}
- Access 블랙리스트: `bl:at:{sha256(accessToken)}` = "1" (TTL=남은 만료)

## Security
- refresh는 HttpOnly 쿠키 `RP_REFRESH` 로만 전달 (dev: SameSite=Lax, secure=false)
- access 블랙리스트로 로그아웃 후 즉시 차단
- 세션 철회/조회는 인증 필요(@PreAuthorize)

## Manual Test
```bash
# 1) 로그인 (쿠키 저장)
curl -i -c cookies.txt -X POST http://localhost:8080/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test2@example.com","password":"1234567890"}'

# 2) 세션 목록
curl -b cookies.txt http://localhost:8080/auth/sessions

# 3) 특정 세션 철회
curl -X DELETE -b cookies.txt http://localhost:8080/auth/sessions/<tid>

# 4) 모든 기기 로그아웃
curl -X POST -b cookies.txt http://localhost:8080/auth/logout-all

# (선택) Redis 확인
docker exec -it rp-redis redis-cli --raw SMEMBERS "rtidx:<userId>"
docker exec -it rp-redis redis-cli --raw SCAN 0 MATCH 'bl:at:*' COUNT 100