### PR TITLE
chore(cors): enable CORS for dev and allow OPTIONS preflight in secur…

### DIFF
--- a/src/main/java/io/routepickapi/config/CorsConfig.java
+++ b/src/main/java/io/routepickapi/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package io.routepickapi.config;
+
+import java.time.Duration;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration cfg = new CorsConfiguration();
+        cfg.setAllowCredentials(true); // 쿠키 주고받기 허용
+        // Flutter 웹 dev 서버 포트가 바뀔 수 있으니 패턴 사용
+        cfg.setAllowedOriginPatterns(List.of("http://localhost:*", "http://127.0.0.1:*"));
+        cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        cfg.setAllowedHeaders(List.of("*")); // content-type, authorization 등 전체 허용
+        // 브라우저가 읽을 수 있게 노출할 헤더
+        cfg.setExposedHeaders(List.of("Set-Cookie"));
+        cfg.setMaxAge(Duration.ofHours(1));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", cfg);
+        return source;
+    }
+}

--- a/src/main/java/io/routepickapi/config/SecurityConfig.java
+++ b/src/main/java/io/routepickapi/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -54,8 +55,10 @@ public class SecurityConfig {
                 .authenticationEntryPoint(authenticationEntryPoint)
                 .accessDeniedHandler(accessDeniedHandler)
             )
+            .cors(Customizer.withDefaults())
             // 인가 규칙
             .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(
                     // Swagger UI & OpenAPI
                     "/v3/api-docs/**",


### PR DESCRIPTION
로컬 개발용 CORS 허용 및 Preflight(OPTIONS) 요청 통과 설정.
Flutter 웹(http://localhost:5173)에서 BE(http://localhost:8080)에 로그인/리프레시 요청 시 쿠키를 포함한 크로스 도메인 통신을 허용