### PR TITLE
fix(course): allow deleting saved recommendations

### DIFF
--- a/src/main/java/io/routepickapi/controller/CourseController.java
+++ b/src/main/java/io/routepickapi/controller/CourseController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
@@ -24,6 +25,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -104,6 +108,19 @@ public class CourseController {
     ) {
         log.info("GET /courses/saved - userId={}", currentUser.id());
         return courseRecommendationSaveService.listSaved(currentUser.id(), pageable);
+    }
+
+    @Operation(summary = "추천 코스 삭제", description = "내가 저장한 추천 코스를 삭제합니다.",
+        security = {@SecurityRequirement(name = "bearerAuth")})
+    @DeleteMapping("/saved/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> deleteSaved(
+        @AuthenticationPrincipal AuthUser currentUser,
+        @PathVariable(name = "id") @Min(1) Long id
+    ) {
+        log.info("DELETE /courses/saved/{} - userId={}", id, currentUser.id());
+        courseRecommendationSaveService.deleteSaved(id, currentUser.id());
+        return ResponseEntity.noContent().build();
     }
 
     private String resolveRateLimitKey(AuthUser currentUser, HttpServletRequest request) {

--- a/src/main/java/io/routepickapi/repository/CourseRecommendationSaveRepository.java
+++ b/src/main/java/io/routepickapi/repository/CourseRecommendationSaveRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface CourseRecommendationSaveRepository
     extends JpaRepository<CourseRecommendationSave, Long> {
 
     @EntityGraph(attributePaths = {"stops"})
     Page<CourseRecommendationSave> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    Optional<CourseRecommendationSave> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/io/routepickapi/service/CourseRecommendationSaveService.java
+++ b/src/main/java/io/routepickapi/service/CourseRecommendationSaveService.java
@@ -63,6 +63,22 @@ public class CourseRecommendationSaveService {
             pageable).map(CourseRecommendationSaveResponse::from);
     }
 
+    @Transactional
+    public void deleteSaved(Long saveId, Long userId) {
+        if (saveId == null) {
+            throw new CustomException(ErrorType.COMMON_INVALID_INPUT, "삭제할 코스 ID가 필요합니다.");
+        }
+
+        User user = requireActiveUser(userId);
+
+        CourseRecommendationSave saved = courseRecommendationSaveRepository
+            .findByIdAndUserId(saveId, user.getId())
+            .orElseThrow(() -> new CustomException(ErrorType.COMMON_NOT_FOUND,
+                "저장된 추천 코스를 찾을 수 없습니다."));
+
+        courseRecommendationSaveRepository.delete(saved);
+    }
+
     private CourseRecommendationStop toStop(CourseStopRequest stop) {
         return new CourseRecommendationStop(
             stop.name(),


### PR DESCRIPTION
# PR 제목 규칙
# feat|fix|refactor|chore|docs|build|ci|test: 간단 설명
# 예) feat(post): add list API with paging

## Summary
저장한 추천 코스를 삭제할 수 있는 API를 추가했습니다.

## Changes
- 추천 코스 삭제 엔드포인트(`/courses/saved/{id}`) 추가
- 서비스/리포지토리에서 사용자 소유 검증 후 삭제 처리
- Swagger 스펙 변화 없음

## Test Plan
- [ ] 로컬 기동 및 스웨거 수동 테스트
- [ ] 핵심 API 성공/실패 케이스 확인
- [ ] DB 쿼리/로그 확인(필요 시)

## Screenshots / Logs (선택)
- `./gradlew clean build` 성공

## Checklist
- [x] 비밀/자격증명 노출 없음
- [x] 예외 포맷(ApiErrorResponse) 준수
- [ ] DTO @Valid 검증 추가/업데이트
- [ ] Swagger(@Operation/@Schema) 설명 반영
- [ ] README/문서 업데이트(필요 시)
- [ ] 관련 이슈 연결: Closes #<번호> (선택)
