### PR TITLE
fix: anonymous drive recommendation + ai explain separation

### DIFF
--- a/src/main/java/io/routepickapi/config/SecurityConfig.java
+++ b/src/main/java/io/routepickapi/config/SecurityConfig.java
@@ -71,6 +71,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/auth/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/auth/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/courses/recommend").permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/recommendations/drive-courses")
+                .permitAll()
                 .requestMatchers(HttpMethod.GET, "/weather/drive-message").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/parking/nearby").permitAll()
                 .requestMatchers(HttpMethod.GET, "/posts/**", "/posts/*/comments/**", "/places/**")

--- a/src/main/java/io/routepickapi/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/io/routepickapi/security/jwt/JwtAuthenticationFilter.java
@@ -117,6 +117,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
                 if (user.getStatus() != UserStatus.ACTIVE) {
+                    if (isPublicRequest(request)) {
+                        log.debug("Inactive user on public endpoint. Skip auth.");
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
                     writeForbiddenResponse(request, response);
                     return;
                 }
@@ -140,6 +145,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    private boolean isPublicRequest(HttpServletRequest request) {
+        String path = request.getServletPath();
+        String method = request.getMethod();
+
+        if ("POST".equalsIgnoreCase(method) && "/courses/recommend".equals(path)) {
+            return true;
+        }
+        if ("GET".equalsIgnoreCase(method)) {
+            if ("/api/recommendations/drive-courses".equals(path)) {
+                return true;
+            }
+            if ("/weather/drive-message".equals(path)) {
+                return true;
+            }
+            if ("/api/parking/nearby".equals(path)) {
+                return true;
+            }
+            if (path.equals("/posts") || path.startsWith("/posts/")) {
+                return true;
+            }
+            if (path.startsWith("/places/")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private void writeForbiddenResponse(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
         ErrorType errorType = ErrorType.USER_STATUS_INACTIVE;
@@ -154,6 +187,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         objectMapper.writeValue(response.getWriter(), body);
     }
-
 
 }


### PR DESCRIPTION


## Summary
비로그인 사용자도 드라이브 코스 추천 가능하도록 수정하고,
AI 설명 기능을 로그인 사용자 전용으로 분리

## Changes
- drive-courses endpoint permitAll 적용
- JWT 필터에서 invalid/inactive 토큰 public endpoint 통과
- FE proxy에서 recommendation 요청 시 Authorization 제거
- 에러 메시지 처리 개선

## Test
- 비로그인 추천 정상 동작 확인
- 로그인 시 explain API 정상 동작
- 만료 토큰 상태에서도 추천 가능 확인

## Checklist
- [x] 비로그인 추천 가능
- [x] explain은 로그인 필요
- [x] 에러 메시지 정상 표시

## Related Issues
- 없음
