### PR TITLE
feat: include stops for drive recommendations

### DIFF
--- a/src/main/java/io/routepickapi/controller/DriveCourseRecommendationController.java
+++ b/src/main/java/io/routepickapi/controller/DriveCourseRecommendationController.java
@@ -181,14 +181,15 @@ public class DriveCourseRecommendationController {
         @Valid @ParameterObject @ModelAttribute RecommendationRequest request
     ) {
         log.info(
-            "GET /api/recommendations/drive-courses - originLat={}, originLng={}, destinationLat={}, destinationLng={}, theme={}, durationMinutes={}, maxStops={}",
+            "GET /api/recommendations/drive-courses - originLat={}, originLng={}, destinationLat={}, destinationLng={}, theme={}, durationMinutes={}, maxStops={}, includeStops={}",
             request.originLat(),
             request.originLng(),
             request.destinationLat(),
             request.destinationLng(),
             request.theme(),
             request.durationMinutes(),
-            request.maxStops()
+            request.maxStops(),
+            request.includeStops() == null ? 0 : request.includeStops().size()
         );
         if (request.destinationLat() == null || request.destinationLng() == null) {
             log.warn("drive-courses destination missing - originLat={}, originLng={}",
@@ -205,7 +206,8 @@ public class DriveCourseRecommendationController {
             request.durationMinutes(),
             request.maxStops(),
             request.departureTime(),
-            request.weatherAware()
+            request.weatherAware(),
+            request.includeStops()
         );
 
         DriveCourseResult result = recommendationFacade.recommend(facadeRequest);

--- a/src/main/java/io/routepickapi/dto/recommendation/IncludeStopRequest.java
+++ b/src/main/java/io/routepickapi/dto/recommendation/IncludeStopRequest.java
@@ -1,0 +1,16 @@
+package io.routepickapi.dto.recommendation;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "코스 포함 요청 정차 지점")
+public record IncludeStopRequest(
+    @Schema(description = "장소명", example = "인왕산 전망대")
+    String name,
+
+    @Schema(description = "위도", example = "37.5921")
+    Double lat,
+
+    @Schema(description = "경도", example = "126.9589")
+    Double lng
+) {
+}

--- a/src/main/java/io/routepickapi/dto/recommendation/RecommendationRequest.java
+++ b/src/main/java/io/routepickapi/dto/recommendation/RecommendationRequest.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
 
 /**
@@ -84,6 +85,10 @@ public record RecommendationRequest(
     /** 날씨 기반 보정 여부 (기본 true). */
     @Parameter(description = "날씨 기반 보정 사용 여부", example = "true")
     @Schema(description = "날씨 기반 보정 사용 여부", example = "true")
-    Boolean weatherAware
+    Boolean weatherAware,
+
+    @Parameter(description = "코스에 포함할 정차 지점 목록")
+    @Schema(description = "코스에 포함할 정차 지점 목록")
+    List<IncludeStopRequest> includeStops
 ) {
 }

--- a/src/main/java/io/routepickapi/service/recommendation/pipeline/CourseGenerationService.java
+++ b/src/main/java/io/routepickapi/service/recommendation/pipeline/CourseGenerationService.java
@@ -25,14 +25,32 @@ public class CourseGenerationService {
     private static final double SIMILARITY_THRESHOLD = 0.6;
 
     public List<CoursePlan> generate(List<Poi> pois, int maxStops, int limit) {
-        if (pois == null || pois.isEmpty()) {
-            return List.of();
+        return generate(pois, List.of(), maxStops, limit);
+    }
+
+    public List<CoursePlan> generate(List<Poi> pois, List<Poi> includeStops, int maxStops, int limit) {
+        int safeLimit = limit > 0 ? limit : DEFAULT_LIMIT;
+        int safeMaxStops = Math.max(MIN_STOPS, Math.min(maxStops, MAX_STOPS));
+        List<Poi> fixedStops = normalizeFixedStops(includeStops);
+        if (!fixedStops.isEmpty()) {
+            safeMaxStops = Math.max(safeMaxStops, Math.min(MAX_STOPS, fixedStops.size()));
         }
 
-        int safeMaxStops = Math.max(MIN_STOPS, Math.min(maxStops, MAX_STOPS));
-        int safeLimit = limit > 0 ? limit : DEFAULT_LIMIT;
+        List<Poi> candidates = pois == null ? List.of() : buildDiverseCandidates(pois);
+        if (fixedStops.isEmpty()) {
+            if (candidates.isEmpty()) {
+                return List.of();
+            }
+            return generateWithCandidates(candidates, safeMaxStops, safeLimit);
+        }
 
-        List<Poi> candidates = buildDiverseCandidates(pois);
+        return generateWithFixedStops(candidates, fixedStops, safeMaxStops, safeLimit);
+    }
+
+    private List<CoursePlan> generateWithCandidates(List<Poi> candidates, int safeMaxStops, int safeLimit) {
+        if (candidates == null || candidates.isEmpty()) {
+            return List.of();
+        }
 
         List<CoursePlan> plans = new ArrayList<>();
         Map<Integer, Integer> generatedByStops = new LinkedHashMap<>();
@@ -59,6 +77,59 @@ public class CourseGenerationService {
             uniqueFirstStops,
             generatedByStops.getOrDefault(2, 0),
             generatedByStops.getOrDefault(3, 0),
+            safeMaxStops
+        );
+        return plans;
+    }
+
+    private List<CoursePlan> generateWithFixedStops(
+        List<Poi> candidates,
+        List<Poi> fixedStops,
+        int safeMaxStops,
+        int safeLimit
+    ) {
+        List<CoursePlan> plans = new ArrayList<>();
+        Set<String> fixedKeys = fixedStops.stream()
+            .map(this::stopKey)
+            .collect(Collectors.toSet());
+        List<Poi> filteredCandidates = candidates == null
+            ? List.of()
+            : candidates.stream()
+                .filter(poi -> !fixedKeys.contains(stopKey(poi)))
+                .toList();
+
+        int fixedCount = fixedStops.size();
+        for (int stopCount = safeMaxStops; stopCount >= MIN_STOPS; stopCount--) {
+            if (stopCount < fixedCount) {
+                continue;
+            }
+            int requiredAdditional = stopCount - fixedCount;
+            if (requiredAdditional == 0) {
+                List<Poi> combined = List.copyOf(fixedStops);
+                if (!isTooSimilar(combined, plans)) {
+                    plans.add(new CoursePlan(combined));
+                }
+            } else if (!filteredCandidates.isEmpty()) {
+                buildCombinationsWithFixedStops(
+                    filteredCandidates,
+                    requiredAdditional,
+                    0,
+                    new ArrayList<>(),
+                    fixedStops,
+                    plans,
+                    safeLimit
+                );
+            }
+
+            if (plans.size() >= safeLimit) {
+                break;
+            }
+        }
+
+        log.info(
+            "고정 경유지 포함 코스 생성 완료 - count={}, fixedStops={}, maxStops={}",
+            plans.size(),
+            fixedStops.size(),
             safeMaxStops
         );
         return plans;
@@ -181,6 +252,45 @@ public class CourseGenerationService {
         }
     }
 
+    private void buildCombinationsWithFixedStops(
+        List<Poi> candidates,
+        int targetSize,
+        int startIndex,
+        List<Poi> current,
+        List<Poi> fixedStops,
+        List<CoursePlan> results,
+        int limit
+    ) {
+        if (results.size() >= limit) {
+            return;
+        }
+        if (current.size() == targetSize) {
+            List<Poi> combined = new ArrayList<>(fixedStops);
+            combined.addAll(current);
+            if (!isTooSimilar(combined, results)) {
+                results.add(new CoursePlan(List.copyOf(combined)));
+            }
+            return;
+        }
+
+        for (int index = startIndex; index < candidates.size(); index++) {
+            if (results.size() >= limit) {
+                return;
+            }
+            current.add(candidates.get(index));
+            buildCombinationsWithFixedStops(
+                candidates,
+                targetSize,
+                index + 1,
+                current,
+                fixedStops,
+                results,
+                limit
+            );
+            current.remove(current.size() - 1);
+        }
+    }
+
     private double baseScore(Poi poi) {
         return poi.viewScore() + poi.driveSuitability();
     }
@@ -241,6 +351,32 @@ public class CourseGenerationService {
             unique.add(poi);
         }
         return unique;
+    }
+
+    private List<Poi> normalizeFixedStops(List<Poi> includeStops) {
+        if (includeStops == null || includeStops.isEmpty()) {
+            return List.of();
+        }
+        List<Poi> normalized = new ArrayList<>();
+        Set<String> seen = new java.util.LinkedHashSet<>();
+        for (Poi poi : includeStops) {
+            if (poi == null) {
+                continue;
+            }
+            String key = stopKey(poi);
+            if (!seen.add(key)) {
+                continue;
+            }
+            normalized.add(poi);
+        }
+        return normalized;
+    }
+
+    private String stopKey(Poi poi) {
+        if (poi == null) {
+            return "";
+        }
+        return poi.source() + ":" + poi.externalId();
     }
 
     private String firstStopKey(Poi poi) {

--- a/src/main/java/io/routepickapi/service/recommendation/pipeline/DriveCourseCommand.java
+++ b/src/main/java/io/routepickapi/service/recommendation/pipeline/DriveCourseCommand.java
@@ -1,6 +1,8 @@
 package io.routepickapi.service.recommendation.pipeline;
 
+import io.routepickapi.dto.recommendation.IncludeStopRequest;
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 드라이브 코스 추천 파이프라인 입력 Command.
@@ -15,6 +17,7 @@ public record DriveCourseCommand(
     Integer durationMinutes,
     Integer maxStops,
     LocalDateTime departureTime,
-    Boolean weatherAware
+    Boolean weatherAware,
+    List<IncludeStopRequest> includeStops
 ) {
 }

--- a/src/main/java/io/routepickapi/service/recommendation/pipeline/RecommendationFacade.java
+++ b/src/main/java/io/routepickapi/service/recommendation/pipeline/RecommendationFacade.java
@@ -5,6 +5,7 @@ import io.routepickapi.common.error.ErrorType;
 import io.routepickapi.domain.course.Course;
 import io.routepickapi.domain.course.CourseStop;
 import io.routepickapi.domain.poi.Poi;
+import io.routepickapi.dto.recommendation.IncludeStopRequest;
 import io.routepickapi.dto.recommendation.GeoPoint;
 import io.routepickapi.infrastructure.client.kakao.KakaoLocalClient;
 import io.routepickapi.infrastructure.client.kakao.dto.KakaoCoordDocument;
@@ -18,10 +19,15 @@ import io.routepickapi.service.recommendation.RouteMetricsService;
 import io.routepickapi.weather.GridConverter;
 import io.routepickapi.weather.WeatherBaseTimeCalculator;
 import io.routepickapi.weather.WeatherBaseTimeCalculator.BaseDateTime;
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +51,13 @@ public class RecommendationFacade {
     private static final List<String> KAKAO_CAFE_KEYWORDS = List.of("카페", "뷰카페");
     private static final double ORIGIN_CLUSTER_LIMIT_KM = 1.0;
     private static final double MIN_COURSE_SCORE = 55.0;
+    private static final int MAX_INCLUDE_STOPS = 3;
+    private static final String INCLUDE_SOURCE = "INCLUDE";
+    private static final String INCLUDE_TAG = "include";
+    private static final double INCLUDE_VIEW_SCORE = 0.4;
+    private static final double INCLUDE_DRIVE_SCORE = 0.4;
+    private static final double INCLUDE_WEATHER_SENSITIVITY = 0.2;
+    private static final int INCLUDE_STAY_MINUTES = 40;
 
     @org.springframework.beans.factory.annotation.Value("${recommendation.cache.version:v1}")
     private String recommendationCacheVersion;
@@ -97,7 +110,8 @@ public class RecommendationFacade {
         log.info("B-structure active - requestId={}, destinationLat={}, destinationLng={}",
             requestId, command.destinationLat(), command.destinationLng());
 
-        String cacheKey = buildResultCacheKey(command);
+        List<IncludeStopRequest> includeStops = normalizeIncludeStops(command.includeStops());
+        String cacheKey = buildResultCacheKey(command, includeStops);
         DriveCourseResult cached = cacheService.getDriveCourseResult(cacheKey);
         if (cached != null) {
             log.info("Recommendation cache hit - requestId={}, key={}", requestId, cacheKey);
@@ -112,6 +126,9 @@ public class RecommendationFacade {
             );
         }
         log.info("Recommendation cache miss - requestId={}, key={}", requestId, cacheKey);
+        if (!includeStops.isEmpty()) {
+            log.info("Include stops applied - requestId={}, count={}", requestId, includeStops.size());
+        }
         LocalDateTime departureTime = command.departureTime() == null
             ? LocalDateTime.now()
             : command.departureTime();
@@ -252,7 +269,13 @@ public class RecommendationFacade {
             requestId, originFiltered.size(), cappedCandidates.size(), curatedUsed);
 
         int planLimit = resolveCap(coursePlanCap, DEFAULT_COURSE_LIMIT);
-        List<CoursePlan> plans = courseGenerationService.generate(cappedCandidates, maxStops, planLimit);
+        List<Poi> includePois = buildIncludePois(includeStops);
+        List<CoursePlan> plans = courseGenerationService.generate(
+            cappedCandidates,
+            includePois,
+            maxStops,
+            planLimit
+        );
         log.info("코스 조합 생성 완료 - requestId={}, plans={}", requestId, plans.size());
 
         String region = resolveRegion(command.originLng(), command.originLat());
@@ -461,7 +484,77 @@ public class RecommendationFacade {
         return value > 0 ? value : fallback;
     }
 
-    private String buildResultCacheKey(DriveCourseCommand command) {
+    private List<IncludeStopRequest> normalizeIncludeStops(List<IncludeStopRequest> includeStops) {
+        if (includeStops == null || includeStops.isEmpty()) {
+            return List.of();
+        }
+        List<IncludeStopRequest> normalized = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (IncludeStopRequest stop : includeStops) {
+            if (stop == null) {
+                continue;
+            }
+            if (stop.lat() == null || stop.lng() == null) {
+                continue;
+            }
+            double lat = stop.lat();
+            double lng = stop.lng();
+            if (lat < -90.0 || lat > 90.0 || lng < -180.0 || lng > 180.0) {
+                continue;
+            }
+            String name = stop.name() == null ? "" : stop.name().trim();
+            if (name.isBlank()) {
+                continue;
+            }
+            String key = includeStopKey(name, lat, lng);
+            if (!seen.add(key)) {
+                continue;
+            }
+            normalized.add(new IncludeStopRequest(name, lat, lng));
+            if (normalized.size() >= MAX_INCLUDE_STOPS) {
+                break;
+            }
+        }
+        return normalized;
+    }
+
+    private String includeStopKey(String name, double lat, double lng) {
+        String normalizedName = name == null ? "" : name.trim().toLowerCase(Locale.ROOT);
+        long latKey = Math.round(lat * 10000);
+        long lngKey = Math.round(lng * 10000);
+        return normalizedName + ":" + latKey + ":" + lngKey;
+    }
+
+    private List<Poi> buildIncludePois(List<IncludeStopRequest> includeStops) {
+        if (includeStops == null || includeStops.isEmpty()) {
+            return List.of();
+        }
+        List<Poi> includePois = new ArrayList<>();
+        for (IncludeStopRequest stop : includeStops) {
+            String name = stop.name().trim();
+            double lat = stop.lat();
+            double lng = stop.lng();
+            String externalId = "include:" + includeStopKey(name, lat, lng);
+            includePois.add(new Poi(
+                INCLUDE_SOURCE,
+                externalId,
+                name,
+                lat,
+                lng,
+                "선택 경유지",
+                Set.of(INCLUDE_TAG),
+                false,
+                INCLUDE_VIEW_SCORE,
+                INCLUDE_WEATHER_SENSITIVITY,
+                Duration.ofMinutes(INCLUDE_STAY_MINUTES),
+                INCLUDE_DRIVE_SCORE
+            ));
+        }
+        return includePois;
+    }
+
+    private String buildResultCacheKey(DriveCourseCommand command, List<IncludeStopRequest> includeStops) {
+        String includeKey = buildIncludeStopsKey(includeStops);
         return "drive-course:"
             + safeKey(recommendationCacheVersion)
             + ":"
@@ -471,7 +564,20 @@ public class RecommendationFacade {
             + ":theme=" + safeKey(command.theme())
             + ":duration=" + command.durationMinutes()
             + ":maxStops=" + command.maxStops()
-            + ":weather=" + command.weatherAware();
+            + ":weather=" + command.weatherAware()
+            + ":include=" + includeKey;
+    }
+
+    private String buildIncludeStopsKey(List<IncludeStopRequest> includeStops) {
+        if (includeStops == null || includeStops.isEmpty()) {
+            return "none";
+        }
+        return includeStops.stream()
+            .map(stop -> safeKey(stop.name())
+                + "@"
+                + String.format("%.5f,%.5f", stop.lat(), stop.lng()))
+            .reduce((first, second) -> first + "|" + second)
+            .orElse("none");
     }
 
     private String safeKey(String value) {


### PR DESCRIPTION


## Summary
추천 API에 includeStops를 추가하고, 고정 포함 스탑을 우선 배치하도록 파이프라인을 확장했습니다.

## Changes
- includeStops DTO/커맨드 추가
- includeStops 정규화/중복 제거/최대 3개 제한
- 코스 생성 시 includeStops 우선 포함
- 캐시 키에 includeStops 반영

## Test
- ./gradlew clean build

## Checklist
- [x] includeStops 파라미터 추가
- [x] 고정 포함 우선 유지
- [x] maxStops 초과 시 include 유지

## Related Issues
- 없음
