### PR TITLE
ci(be): add github actions workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,31 @@
+name: CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch or tag to deploy
+        required: true
+        default: dev
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            set -e
+            cd /home/ubuntu/routepick-be
+            git fetch --all
+            git checkout ${{ inputs.ref }}
+            git pull origin ${{ inputs.ref }}
+            docker compose -f docker-compose.prod.yml up -d --build
+            docker compose -f docker-compose.prod.yml ps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: '21'
+          cache: gradle
+
+      - name: Build
+        run: ./gradlew clean build --no-daemon

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ io.routepickapi
 
 ---
 
+## 🤖 CI/CD (GitHub Actions)
+- CI: `dev` 브랜치 push/PR 시 `./gradlew clean build` 수행
+- CD: `workflow_dispatch`로 EC2에 수동 배포(`docker compose`)
+- GitHub Secrets: `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
+
+---
+
 ### 🐳 Docker Compose (prod)
 
 ```


### PR DESCRIPTION
# PR 제목 규칙
# feat|fix|refactor|chore|docs|build|ci|test: 간단 설명
# 예) feat(post): add list API with paging

## Summary
GitHub Actions 기반 CI/CD 워크플로우를 추가하고 README에 사용 방법을 정리했습니다.

## Changes
- `dev` 브랜치 PR/푸시 시 CI 빌드(`./gradlew clean build`) 수행
- `workflow_dispatch`로 EC2 수동 배포(CD) 워크플로우 추가
- README에 CI/CD 및 GitHub Secrets 안내 추가
- Swagger 스펙 변화 없음

## Test Plan
- [ ] 로컬 기동 및 스웨거 수동 테스트
- [ ] 핵심 API 성공/실패 케이스 확인
- [ ] DB 쿼리/로그 확인(필요 시)

## Screenshots / Logs (선택)
- 스크린샷, curl 결과, 주요 로그 등

## Checklist
- [ ] 비밀/자격증명 노출 없음
- [ ] 예외 포맷(ApiErrorResponse) 준수
- [ ] DTO @Valid 검증 추가/업데이트
- [ ] Swagger(@Operation/@Schema) 설명 반영
- [ ] README/문서 업데이트(필요 시)
- [ ] 관련 이슈 연결: Closes #<번호> (선택)
