### PR TITLE
fix(ci): set cd default to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,7 @@ on:
       ref:
         description: Branch or tag to deploy
         required: true
-        default: dev
+        default: main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ io.routepickapi
 
 ## 🤖 CI/CD (GitHub Actions)
 - CI: `dev` 브랜치 push/PR 시 `./gradlew clean build` 수행
-- CD: `workflow_dispatch`로 EC2에 수동 배포(`docker compose`)
+- CD: `workflow_dispatch`로 `main` 브랜치 수동 배포(`docker compose`)
 - GitHub Secrets: `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
 
 ---


### PR DESCRIPTION
# PR 제목 규칙
# feat|fix|refactor|chore|docs|build|ci|test: 간단 설명
# 예) feat(post): add list API with paging

## Summary
CD 워크플로우의 기본 배포 브랜치를 `main`으로 변경했습니다.

## Changes
- CD `workflow_dispatch` 기본 ref를 `main`으로 수정
- README에 배포 브랜치 안내 문구 갱신
- Swagger 스펙 변화 없음

## Test Plan
- [ ] 로컬 기동 및 스웨거 수동 테스트
- [ ] 핵심 API 성공/실패 케이스 확인
- [ ] DB 쿼리/로그 확인(필요 시)

## Screenshots / Logs (선택)
- 스크린샷, curl 결과, 주요 로그 등

## Checklist
- [ ] 비밀/자격증명 노출 없음
- [ ] 예외 포맷(ApiErrorResponse) 준수
- [ ] DTO @Valid 검증 추가/업데이트
- [ ] Swagger(@Operation/@Schema) 설명 반영
- [ ] README/문서 업데이트(필요 시)
- [ ] 관련 이슈 연결: Closes #<번호> (선택)
