### PR TITLE
ci(be): auto deploy on main push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,8 @@
 name: CD
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       ref:
@@ -14,6 +16,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: production
+    env:
+      TARGET_REF: ${{ inputs.ref || github.ref_name }}
     steps:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
@@ -25,7 +30,7 @@ jobs:
             set -e
             cd /home/ubuntu/routepick-be
             git fetch --all
-            git checkout ${{ inputs.ref }}
-            git pull origin ${{ inputs.ref }}
+            git checkout ${{ env.TARGET_REF }}
+            git pull origin ${{ env.TARGET_REF }}
             docker compose -f docker-compose.prod.yml up -d --build
             docker compose -f docker-compose.prod.yml ps

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ io.routepickapi
 
 ## 🤖 CI/CD (GitHub Actions)
 - CI: `dev` 브랜치 push/PR 시 `./gradlew clean build` 수행
-- CD: `workflow_dispatch`로 `main` 브랜치 수동 배포(`docker compose`)
+- CD: `main` push 시 자동 배포(Production 승인 후), 필요 시 `workflow_dispatch`로 수동 배포
 - GitHub Secrets: `EC2_HOST`, `EC2_USER`, `EC2_SSH_KEY`
 
 ---


### PR DESCRIPTION
# PR 제목 규칙
# feat|fix|refactor|chore|docs|build|ci|test: 간단 설명
# 예) feat(post): add list API with paging

## Summary
main 푸시 시 자동 배포되도록 CD 워크플로우를 보강하고, Production 승인 환경을 적용했습니다.

## Changes
- main push 트리거 추가 및 배포 ref 자동 선택
- Production 환경 승인 게이트 적용
- README의 CD 안내 문구 업데이트
- Swagger 스펙 변화 없음

## Test Plan
- [ ] 로컬 기동 및 스웨거 수동 테스트
- [ ] 핵심 API 성공/실패 케이스 확인
- [ ] DB 쿼리/로그 확인(필요 시)

## Screenshots / Logs (선택)
- 스크린샷, curl 결과, 주요 로그 등

## Checklist
- [ ] 비밀/자격증명 노출 없음
- [ ] 예외 포맷(ApiErrorResponse) 준수
- [ ] DTO @Valid 검증 추가/업데이트
- [ ] Swagger(@Operation/@Schema) 설명 반영
- [ ] README/문서 업데이트(필요 시)
- [ ] 관련 이슈 연결: Closes #<번호> (선택)
