### PR TITLE
ci(be): add redis service for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# PR 제목 규칙
# feat|fix|refactor|chore|docs|build|ci|test: 간단 설명
# 예) feat(post): add list API with paging

## Summary
CI 환경에서 Redis 연결 실패로 테스트가 깨져 Redis 서비스 컨테이너를 추가했습니다.

## Changes
- GitHub Actions CI에 Redis 서비스 추가(health check 포함)
- Swagger 스펙 변화 없음

## Test Plan
- [ ] 로컬 기동 및 스웨거 수동 테스트
- [ ] 핵심 API 성공/실패 케이스 확인
- [ ] DB 쿼리/로그 확인(필요 시)

## Screenshots / Logs (선택)
- 스크린샷, curl 결과, 주요 로그 등

## Checklist
- [ ] 비밀/자격증명 노출 없음
- [ ] 예외 포맷(ApiErrorResponse) 준수
- [ ] DTO @Valid 검증 추가/업데이트
- [ ] Swagger(@Operation/@Schema) 설명 반영
- [ ] README/문서 업데이트(필요 시)
- [ ] 관련 이슈 연결: Closes #<번호> (선택)
